### PR TITLE
feat(ui-lib): v0.1.0 — compound components + Apple design system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,26 @@
       "version": "0.0.4",
       "dependencies": {
         "@faker-js/faker": "^9.7.0",
+        "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-checkbox": "^1.3.3",
+        "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-radio-group": "^1.3.8",
+        "@radix-ui/react-scroll-area": "^1.2.10",
+        "@radix-ui/react-select": "^2.2.6",
+        "@radix-ui/react-separator": "^1.1.8",
+        "@radix-ui/react-switch": "^1.2.6",
+        "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "motion": "^12.6.5",
+        "react-hook-form": "^7.71.2",
         "recharts": "^3.6.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
@@ -2753,6 +2762,12 @@
         "node": ">=14"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
@@ -2776,6 +2791,89 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.11.tgz",
+      "integrity": "sha512-0Qk603AHGV28BOBO34p7IgD5m+V5Sg/YovfayABkoDDBM5d3NCx0Mp4gGrjzLGes1jV5eNOE1r3itqOR33VC6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.4",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-context": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz",
+      "integrity": "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2858,6 +2956,42 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -3245,6 +3379,144 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
+      "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
+      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-visually-hidden": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.8.tgz",
+      "integrity": "sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
@@ -3258,6 +3530,65 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -3350,6 +3681,24 @@
       "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz",
+      "integrity": "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.5.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -4908,17 +5257,6 @@
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
       "dev": true
-    },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
-      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
     },
     "node_modules/@swc/jest": {
       "version": "0.2.37",
@@ -13221,6 +13559,22 @@
         "react": "^19.2.3"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.71.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.2.tgz",
+      "integrity": "sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -13956,6 +14310,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,10 @@
 {
   "name": "@junseop-shin/my-ui-lib",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "type": "module",
   "peerDependencies": {
     "@xyflow/react": "^12.0.0",
     "lucide-react": "^0.562.0",
-    "next": ">=15.0.0",
     "react": "^19.0.0"
   },
   "main": "./dist/my-ui-lib.umd.js",
@@ -37,17 +36,26 @@
   },
   "dependencies": {
     "@faker-js/faker": "^9.7.0",
+    "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-radio-group": "^1.3.8",
+    "@radix-ui/react-scroll-area": "^1.2.10",
+    "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-separator": "^1.1.8",
+    "@radix-ui/react-switch": "^1.2.6",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "motion": "^12.6.5",
+    "react-hook-form": "^7.71.2",
     "recharts": "^3.6.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/src/components/atoms/Avatar.tsx
+++ b/src/components/atoms/Avatar.tsx
@@ -1,0 +1,70 @@
+import * as React from "react"
+import * as AvatarPrimitive from "@radix-ui/react-avatar"
+import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "@/lib/utils"
+
+const avatarVariants = cva(
+  "relative flex shrink-0 overflow-hidden rounded-full",
+  {
+    variants: {
+      size: {
+        sm: "h-8 w-8",
+        md: "h-10 w-10",
+        lg: "h-12 w-12",
+        xl: "h-16 w-16",
+      },
+    },
+    defaultVariants: { size: "md" },
+  }
+)
+
+/* ─── Root ─── */
+const AvatarRoot = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root> &
+    VariantProps<typeof avatarVariants>
+>(({ className, size, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn(avatarVariants({ size }), className)}
+    {...props}
+  />
+))
+AvatarRoot.displayName = AvatarPrimitive.Root.displayName
+
+/* ─── Image ─── */
+const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full object-cover", className)}
+    {...props}
+  />
+))
+AvatarImage.displayName = AvatarPrimitive.Image.displayName
+
+/* ─── Fallback ─── */
+const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-muted text-muted-foreground text-sm font-medium",
+      className
+    )}
+    {...props}
+  />
+))
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName
+
+/* ─── Compound ─── */
+const Avatar = Object.assign(AvatarRoot, {
+  Image: AvatarImage,
+  Fallback: AvatarFallback,
+})
+
+export { Avatar, AvatarImage, AvatarFallback }

--- a/src/components/atoms/Badge.tsx
+++ b/src/components/atoms/Badge.tsx
@@ -1,21 +1,45 @@
-import { clsx, type ClassValue } from 'clsx';
-import { twMerge } from 'tailwind-merge';
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "@/lib/utils"
 
-function cn(...inputs: ClassValue[]) {
-    return twMerge(clsx(inputs));
-}
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors",
+  {
+    variants: {
+      variant: {
+        default:
+          "border-transparent bg-primary/10 text-primary",
+        secondary:
+          "border-transparent bg-secondary text-secondary-foreground",
+        outline:
+          "border-border text-foreground",
+        destructive:
+          "border-transparent bg-destructive/10 text-destructive",
+        success:
+          "border-transparent bg-success/10 text-success",
+        warning:
+          "border-transparent bg-warning/10 text-warning-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
 
-export function Badge({ children, variant = 'default' }: { children: React.ReactNode, variant?: 'default' | 'success' | 'destructive' | 'outline' }) {
-    const variants = {
-        default: "bg-blue-900/20 text-blue-400 border-blue-900/50",
-        success: "bg-emerald-900/20 text-emerald-400 border-emerald-900/50",
-        destructive: "bg-red-900/20 text-red-400 border-red-900/50",
-        outline: "text-slate-400 border-slate-800"
-    };
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof badgeVariants> {}
 
-    return (
-        <span className={cn("inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2", variants[variant])}>
-            {children}
-        </span>
-    );
-}
+const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
+  ({ className, variant, ...props }, ref) => (
+    <span
+      ref={ref}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+)
+Badge.displayName = "Badge"
+
+export { Badge, badgeVariants }

--- a/src/components/atoms/Button.tsx
+++ b/src/components/atoms/Button.tsx
@@ -1,47 +1,53 @@
-import { cva, type VariantProps } from "class-variance-authority";
-import * as React from "react";
-import { cn } from "@/lib/utils";
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 select-none cursor-pointer",
   {
     variants: {
       variant: {
-        primary: "bg-blue-600 text-white hover:bg-blue-700",
-        secondary: "bg-gray-100 text-gray-900 hover:bg-gray-200",
-        danger: "bg-red-600 text-white hover:bg-red-700",
-        ghost: "hover:bg-gray-100 hover:text-gray-900",
-        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        default:
+          "bg-primary text-primary-foreground hover:opacity-90 active:scale-[0.97]",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-accent active:scale-[0.97]",
+        outline:
+          "border border-border bg-transparent text-foreground hover:bg-accent active:scale-[0.97]",
+        ghost:
+          "bg-transparent text-foreground hover:bg-accent active:scale-[0.97]",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:opacity-90 active:scale-[0.97]",
+        link: "bg-transparent text-primary underline-offset-4 hover:underline h-auto p-0",
       },
       size: {
-        sm: "h-9 rounded-md px-3",
-        md: "h-10 px-4 py-2",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
+        sm: "h-8 rounded-full px-4 text-xs",
+        md: "h-10 rounded-full px-5 text-sm",
+        lg: "h-12 rounded-full px-7 text-base",
+        icon: "h-10 w-10 rounded-full",
+        "icon-sm": "h-8 w-8 rounded-full",
+        "icon-lg": "h-12 w-12 rounded-full",
       },
     },
     defaultVariants: {
-      variant: "primary",
+      variant: "default",
       size: "md",
     },
   }
-);
+)
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-  VariantProps<typeof buttonVariants> { }
+    VariantProps<typeof buttonVariants> {}
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, ...props }, ref) => {
-    return (
-      <button
-        className={cn(buttonVariants({ variant, size, className }))}
-        ref={ref}
-        {...props}
-      />
-    );
-  }
-);
-Button.displayName = "Button";
+  ({ className, variant, size, ...props }, ref) => (
+    <button
+      ref={ref}
+      className={cn(buttonVariants({ variant, size }), className)}
+      {...props}
+    />
+  )
+)
+Button.displayName = "Button"
 
-export { Button, buttonVariants };
+export { Button, buttonVariants }

--- a/src/components/atoms/Card.tsx
+++ b/src/components/atoms/Card.tsx
@@ -1,14 +1,101 @@
-import { clsx, type ClassValue } from 'clsx';
-import { twMerge } from 'tailwind-merge';
+import * as React from "react"
+import { cn } from "@/lib/utils"
 
-function cn(...inputs: ClassValue[]) {
-    return twMerge(clsx(inputs));
-}
+/* ─── Root ─── */
+const CardRoot = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-2xl border border-border bg-card text-card-foreground shadow-sm transition-shadow hover:shadow-md",
+      className
+    )}
+    {...props}
+  />
+))
+CardRoot.displayName = "Card"
 
-export function Card({ className, children }: { className?: string, children: React.ReactNode }) {
-    return (
-        <div className={cn("rounded-lg border border-slate-800 bg-slate-900/50 text-slate-200 shadow-sm", className)}>
-            {children}
-        </div>
-    );
+/* ─── Header ─── */
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col gap-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "Card.Header"
+
+/* ─── Title ─── */
+const CardTitle = React.forwardRef<
+  HTMLHeadingElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn("font-semibold leading-tight tracking-tight text-foreground", className)}
+    {...props}
+  />
+))
+CardTitle.displayName = "Card.Title"
+
+/* ─── Description ─── */
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "Card.Description"
+
+/* ─── Content ─── */
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardContent.displayName = "Card.Content"
+
+/* ─── Footer ─── */
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "Card.Footer"
+
+/* ─── Compound export ─── */
+const Card = Object.assign(CardRoot, {
+  Header: CardHeader,
+  Title: CardTitle,
+  Description: CardDescription,
+  Content: CardContent,
+  Footer: CardFooter,
+})
+
+export {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
 }

--- a/src/components/atoms/Checkbox.tsx
+++ b/src/components/atoms/Checkbox.tsx
@@ -1,9 +1,6 @@
-"use client"
-
 import * as React from "react"
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
 import { Check } from "lucide-react"
-
 import { cn } from "@/lib/utils"
 
 const Checkbox = React.forwardRef<
@@ -13,15 +10,16 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      "peer h-[18px] w-[18px] shrink-0 rounded-[5px] border border-border bg-background transition-colors",
+      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "disabled:cursor-not-allowed disabled:opacity-50",
+      "data-[state=checked]:bg-primary data-[state=checked]:border-primary data-[state=checked]:text-primary-foreground",
       className
     )}
     {...props}
   >
-    <CheckboxPrimitive.Indicator
-      className={cn("flex items-center justify-center text-current")}
-    >
-      <Check className="h-4 w-4" />
+    <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current">
+      <Check className="h-3 w-3 stroke-[3]" />
     </CheckboxPrimitive.Indicator>
   </CheckboxPrimitive.Root>
 ))

--- a/src/components/atoms/Dialog.tsx
+++ b/src/components/atoms/Dialog.tsx
@@ -1,0 +1,112 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+const DialogRoot = DialogPrimitive.Root
+const DialogTrigger = DialogPrimitive.Trigger
+const DialogPortal = DialogPrimitive.Portal
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/40 backdrop-blur-sm",
+      "data-[state=open]:animate-in data-[state=closed]:animate-out",
+      "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 w-full max-w-lg translate-x-[-50%] translate-y-[-50%]",
+        "rounded-2xl border border-border bg-background p-6 shadow-xl",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%]",
+        "data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
+        "duration-200",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-full p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col gap-1.5 mb-4", className)} {...props} />
+)
+DialogHeader.displayName = "Dialog.Header"
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex justify-end gap-2 mt-6", className)} {...props} />
+)
+DialogFooter.displayName = "Dialog.Footer"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold leading-tight text-foreground", className)}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+const Dialog = Object.assign(DialogRoot, {
+  Trigger: DialogTrigger,
+  Content: DialogContent,
+  Header: DialogHeader,
+  Footer: DialogFooter,
+  Title: DialogTitle,
+  Description: DialogDescription,
+  Close: DialogClose,
+})
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+  DialogClose,
+}

--- a/src/components/atoms/Input.tsx
+++ b/src/components/atoms/Input.tsx
@@ -1,59 +1,24 @@
-import * as React from "react";
-import { cn } from "@/lib/utils";
-import { Label } from "@/components/atoms/Label";
+import * as React from "react"
+import { cn } from "@/lib/utils"
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {
-  label?: string;
-  helperText?: string;
-  error?: boolean;
-}
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, label, helperText, error, id, ...props }, ref) => {
-    // Generate a unique ID if one isn't provided, to link label and input
-    const generatedId = React.useId();
-    const inputId = id || generatedId;
-    const helperTextId = helperText ? `${inputId}-helper` : undefined;
+  ({ className, type, ...props }, ref) => (
+    <input
+      type={type}
+      ref={ref}
+      className={cn(
+        "flex h-10 w-full rounded-xl border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:border-transparent",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        "aria-invalid:border-destructive aria-invalid:focus-visible:ring-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Input.displayName = "Input"
 
-    return (
-      <div className="grid w-full max-w-sm items-center gap-1.5">
-        {label && (
-          <Label
-            htmlFor={inputId}
-            className="mb-2" // Add margin for spacing if needed, keeping existing styles via Label atom
-          >
-            {label}
-          </Label>
-        )}
-        <input
-          type={type}
-          id={inputId}
-          aria-describedby={helperTextId}
-          aria-invalid={error}
-          className={cn(
-            "flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder:text-gray-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
-            error && "border-red-500 focus-visible:ring-red-500",
-            className
-          )}
-          ref={ref}
-          {...props}
-        />
-        {helperText && (
-          <p
-            id={helperTextId}
-            className={cn(
-              "text-sm text-gray-500",
-              error && "text-red-500"
-            )}
-          >
-            {helperText}
-          </p>
-        )}
-      </div>
-    );
-  }
-);
-Input.displayName = "Input";
-
-export { Input };
+export { Input }

--- a/src/components/atoms/Label.tsx
+++ b/src/components/atoms/Label.tsx
@@ -1,24 +1,20 @@
 import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
-import { cva, type VariantProps } from "class-variance-authority"
-
 import { cn } from "@/lib/utils"
 
-const labelVariants = cva(
-    "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-)
-
 const Label = React.forwardRef<
-    React.ElementRef<typeof LabelPrimitive.Root>,
-    React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
-    VariantProps<typeof labelVariants>
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
 >(({ className, ...props }, ref) => (
-    <LabelPrimitive.Root
-        ref={ref}
-        className={cn(labelVariants(), className)}
-        {...props}
-    />
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(
+      "text-sm font-medium text-foreground leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+      className
+    )}
+    {...props}
+  />
 ))
 Label.displayName = LabelPrimitive.Root.displayName
 
-export { Label, labelVariants }
+export { Label }

--- a/src/components/atoms/RadioGroup.tsx
+++ b/src/components/atoms/RadioGroup.tsx
@@ -1,41 +1,39 @@
-import * as React from "react";
-import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
-import { Circle } from "lucide-react";
-import { cn } from "@/lib/utils";
+import * as React from "react"
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
+import { cn } from "@/lib/utils"
 
 const RadioGroup = React.forwardRef<
   React.ElementRef<typeof RadioGroupPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
->(({ className, ...props }, ref) => {
-  return (
-    <RadioGroupPrimitive.Root
-      className={cn("grid gap-2", className)}
-      {...props}
-      ref={ref}
-    />
-  );
-});
-RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
+>(({ className, ...props }, ref) => (
+  <RadioGroupPrimitive.Root
+    ref={ref}
+    className={cn("grid gap-2", className)}
+    {...props}
+  />
+))
+RadioGroup.displayName = RadioGroupPrimitive.Root.displayName
 
 const RadioGroupItem = React.forwardRef<
   React.ElementRef<typeof RadioGroupPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
->(({ className, ...props }, ref) => {
-  return (
-    <RadioGroupPrimitive.Item
-      ref={ref}
-      className={cn(
-        "aspect-square h-4 w-4 rounded-full border border-gray-900 text-blue-600 shadow focus:outline-none focus-visible:ring-1 focus-visible:ring-gray-950 disabled:cursor-not-allowed disabled:opacity-50",
-        className
-      )}
-      {...props}
-    >
-      <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
-        <Circle className="h-2.5 w-2.5 fill-current text-current" />
-      </RadioGroupPrimitive.Indicator>
-    </RadioGroupPrimitive.Item>
-  );
-});
-RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName;
+>(({ className, ...props }, ref) => (
+  <RadioGroupPrimitive.Item
+    ref={ref}
+    className={cn(
+      "aspect-square h-4 w-4 rounded-full border border-border text-primary transition-colors",
+      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "disabled:cursor-not-allowed disabled:opacity-50",
+      "data-[state=checked]:border-primary data-[state=checked]:bg-primary",
+      className
+    )}
+    {...props}
+  >
+    <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+      <div className="h-1.5 w-1.5 rounded-full bg-primary-foreground" />
+    </RadioGroupPrimitive.Indicator>
+  </RadioGroupPrimitive.Item>
+))
+RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName
 
-export { RadioGroup, RadioGroupItem };
+export { RadioGroup, RadioGroupItem }

--- a/src/components/atoms/ScrollArea.tsx
+++ b/src/components/atoms/ScrollArea.tsx
@@ -1,14 +1,49 @@
-import { clsx, type ClassValue } from 'clsx';
-import { twMerge } from 'tailwind-merge';
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+import { cn } from "@/lib/utils"
 
-function cn(...inputs: ClassValue[]) {
-    return twMerge(clsx(inputs));
-}
+const ScrollAreaRoot = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn("relative overflow-hidden", className)}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+))
+ScrollAreaRoot.displayName = ScrollAreaPrimitive.Root.displayName
 
-export function ScrollArea({ className, children }: { className?: string, children: React.ReactNode }) {
-    return (
-        <div className={cn("overflow-auto scrollbar-thin scrollbar-thumb-slate-700 scrollbar-track-slate-900", className)}>
-            {children}
-        </div>
-    );
-}
+const ScrollBar = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = "vertical", ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      "flex touch-none select-none transition-colors",
+      orientation === "vertical" && "h-full w-2 border-l border-l-transparent p-[1px]",
+      orientation === "horizontal" && "h-2 flex-col border-t border-t-transparent p-[1px]",
+      className
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb
+      className="relative flex-1 rounded-full bg-border hover:bg-muted-foreground/30 transition-colors"
+    />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+))
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName
+
+const ScrollArea = Object.assign(ScrollAreaRoot, {
+  ScrollBar,
+})
+
+export { ScrollArea, ScrollBar }

--- a/src/components/atoms/Select.tsx
+++ b/src/components/atoms/Select.tsx
@@ -1,0 +1,165 @@
+import * as React from "react"
+import * as SelectPrimitive from "@radix-ui/react-select"
+import { Check, ChevronDown, ChevronUp } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+const SelectRoot = SelectPrimitive.Root
+const SelectGroup = SelectPrimitive.Group
+const SelectValue = SelectPrimitive.Value
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full items-center justify-between rounded-xl border border-input bg-background px-3 py-2 text-sm text-foreground transition-colors",
+      "placeholder:text-muted-foreground",
+      "focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent",
+      "disabled:cursor-not-allowed disabled:opacity-50",
+      "[&>span]:line-clamp-1",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 text-muted-foreground shrink-0" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+))
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+))
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+))
+SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-2xl border border-border bg-popover text-popover-foreground shadow-lg",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
+        "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" && "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+))
+SelectContent.displayName = SelectPrimitive.Content.displayName
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-xs font-semibold text-muted-foreground", className)}
+    {...props}
+  />
+))
+SelectLabel.displayName = SelectPrimitive.Label.displayName
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-lg py-1.5 pl-8 pr-2 text-sm outline-none transition-colors",
+      "focus:bg-accent focus:text-accent-foreground",
+      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4 text-primary" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+))
+SelectItem.displayName = SelectPrimitive.Item.displayName
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-border", className)}
+    {...props}
+  />
+))
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+
+const Select = Object.assign(SelectRoot, {
+  Group: SelectGroup,
+  Value: SelectValue,
+  Trigger: SelectTrigger,
+  Content: SelectContent,
+  Label: SelectLabel,
+  Item: SelectItem,
+  Separator: SelectSeparator,
+})
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+}

--- a/src/components/atoms/Separator.tsx
+++ b/src/components/atoms/Separator.tsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+import { cn } from "@/lib/utils"
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(({ className, orientation = "horizontal", decorative = true, ...props }, ref) => (
+  <SeparatorPrimitive.Root
+    ref={ref}
+    decorative={decorative}
+    orientation={orientation}
+    className={cn(
+      "shrink-0 bg-border",
+      orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
+      className
+    )}
+    {...props}
+  />
+))
+Separator.displayName = SeparatorPrimitive.Root.displayName
+
+export { Separator }

--- a/src/components/atoms/Switch.tsx
+++ b/src/components/atoms/Switch.tsx
@@ -1,0 +1,30 @@
+import * as React from "react"
+import * as SwitchPrimitive from "@radix-ui/react-switch"
+import { cn } from "@/lib/utils"
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitive.Root
+    ref={ref}
+    className={cn(
+      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors",
+      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "disabled:cursor-not-allowed disabled:opacity-50",
+      "data-[state=unchecked]:bg-muted data-[state=checked]:bg-primary",
+      className
+    )}
+    {...props}
+  >
+    <SwitchPrimitive.Thumb
+      className={cn(
+        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-sm ring-0 transition-transform",
+        "data-[state=unchecked]:translate-x-0 data-[state=checked]:translate-x-5"
+      )}
+    />
+  </SwitchPrimitive.Root>
+))
+Switch.displayName = SwitchPrimitive.Root.displayName
+
+export { Switch }

--- a/src/components/atoms/Tag.tsx
+++ b/src/components/atoms/Tag.tsx
@@ -1,0 +1,66 @@
+import * as React from "react"
+import { X } from "lucide-react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { cn } from "@/lib/utils"
+
+const tagVariants = cva(
+  "inline-flex items-center gap-1 rounded-full font-medium transition-colors select-none",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-secondary text-secondary-foreground",
+        primary:
+          "bg-primary/10 text-primary",
+        outline:
+          "border border-border text-foreground bg-transparent",
+        destructive:
+          "bg-destructive/10 text-destructive",
+        success:
+          "bg-success/10 text-success",
+      },
+      size: {
+        sm: "h-6 px-2.5 text-xs",
+        md: "h-7 px-3 text-xs",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "md",
+    },
+  }
+)
+
+export interface TagProps
+  extends React.HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof tagVariants> {
+  onDismiss?: () => void
+}
+
+const Tag = React.forwardRef<HTMLSpanElement, TagProps>(
+  ({ className, variant, size, onDismiss, children, ...props }, ref) => (
+    <span
+      ref={ref}
+      className={cn(tagVariants({ variant, size }), className)}
+      {...props}
+    >
+      {children}
+      {onDismiss && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            onDismiss()
+          }}
+          className="ml-0.5 rounded-full p-0.5 hover:bg-black/10 dark:hover:bg-white/10 transition-colors focus:outline-none"
+          aria-label="Remove tag"
+        >
+          <X className="h-2.5 w-2.5" />
+        </button>
+      )}
+    </span>
+  )
+)
+Tag.displayName = "Tag"
+
+export { Tag, tagVariants }

--- a/src/components/atoms/Textarea.tsx
+++ b/src/components/atoms/Textarea.tsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => (
+    <textarea
+      ref={ref}
+      className={cn(
+        "flex min-h-[80px] w-full rounded-xl border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground transition-colors resize-none",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:border-transparent",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        "aria-invalid:border-destructive aria-invalid:focus-visible:ring-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Textarea.displayName = "Textarea"
+
+export { Textarea }

--- a/src/components/atoms/Toaster.tsx
+++ b/src/components/atoms/Toaster.tsx
@@ -1,0 +1,28 @@
+import { Toaster as SonnerToaster, toast } from "sonner"
+
+export type ToasterProps = React.ComponentProps<typeof SonnerToaster>
+
+function Toaster({ ...props }: ToasterProps) {
+  return (
+    <SonnerToaster
+      position="bottom-right"
+      toastOptions={{
+        classNames: {
+          toast:
+            "group flex items-center gap-2 rounded-2xl border border-border bg-background text-foreground shadow-lg px-4 py-3 text-sm font-medium",
+          description: "text-muted-foreground text-xs font-normal",
+          actionButton: "bg-primary text-primary-foreground rounded-full px-3 py-1 text-xs font-medium",
+          cancelButton: "bg-muted text-muted-foreground rounded-full px-3 py-1 text-xs font-medium",
+          closeButton: "text-muted-foreground hover:text-foreground",
+          error: "!bg-destructive/10 !border-destructive/20 !text-destructive",
+          success: "!bg-success/10 !border-success/20 !text-success",
+          warning: "!bg-warning/10 !border-warning/20 !text-warning-foreground",
+          info: "!bg-primary/10 !border-primary/20 !text-primary",
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster, toast }

--- a/src/components/atoms/Tooltip.tsx
+++ b/src/components/atoms/Tooltip.tsx
@@ -1,32 +1,39 @@
 import * as React from "react"
 import * as TooltipPrimitive from "@radix-ui/react-tooltip"
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
-
-function cn(...inputs: ClassValue[]) {
-    return twMerge(clsx(inputs))
-}
+import { cn } from "@/lib/utils"
 
 const TooltipProvider = TooltipPrimitive.Provider
 
-const Tooltip = TooltipPrimitive.Root
+const TooltipRoot = TooltipPrimitive.Root
 
 const TooltipTrigger = TooltipPrimitive.Trigger
 
 const TooltipContent = React.forwardRef<
-    React.ElementRef<typeof TooltipPrimitive.Content>,
-    React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 6, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
     <TooltipPrimitive.Content
-        ref={ref}
-        sideOffset={sideOffset}
-        className={cn(
-            "z-50 overflow-hidden rounded-md border bg-slate-900 px-3 py-1.5 text-sm text-slate-50 shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-            className
-        )}
-        {...props}
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 overflow-hidden rounded-xl bg-foreground px-3 py-1.5 text-xs text-background shadow-md",
+        "animate-in fade-in-0 zoom-in-95",
+        "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+        "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
+        "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
     />
+  </TooltipPrimitive.Portal>
 ))
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
+const Tooltip = Object.assign(TooltipRoot, {
+  Provider: TooltipProvider,
+  Trigger: TooltipTrigger,
+  Content: TooltipContent,
+})
+
+export { Tooltip, TooltipProvider, TooltipTrigger, TooltipContent }

--- a/src/components/atoms/__tests__/Badge.test.tsx
+++ b/src/components/atoms/__tests__/Badge.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Badge } from '../Badge'
+
+describe('Badge', () => {
+  it('renders children', () => {
+    render(<Badge>New</Badge>)
+    expect(screen.getByText('New')).toBeInTheDocument()
+  })
+
+  it('applies default variant', () => {
+    render(<Badge>Default</Badge>)
+    expect(screen.getByText('Default')).toHaveClass('bg-primary/10')
+  })
+
+  it('applies success variant', () => {
+    render(<Badge variant="success">Live</Badge>)
+    expect(screen.getByText('Live')).toHaveClass('bg-success/10')
+  })
+
+  it('applies destructive variant', () => {
+    render(<Badge variant="destructive">Error</Badge>)
+    expect(screen.getByText('Error')).toHaveClass('bg-destructive/10')
+  })
+
+  it('applies outline variant', () => {
+    render(<Badge variant="outline">Draft</Badge>)
+    expect(screen.getByText('Draft')).toHaveClass('border-border')
+  })
+})

--- a/src/components/atoms/__tests__/Button.test.tsx
+++ b/src/components/atoms/__tests__/Button.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Button } from '../Button'
+
+describe('Button', () => {
+  it('renders children', () => {
+    render(<Button>Click me</Button>)
+    expect(screen.getByRole('button', { name: 'Click me' })).toBeInTheDocument()
+  })
+
+  it('calls onClick when clicked', async () => {
+    const onClick = vi.fn()
+    render(<Button onClick={onClick}>Click</Button>)
+    await userEvent.click(screen.getByRole('button'))
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('is disabled when disabled prop is set', async () => {
+    const onClick = vi.fn()
+    render(<Button disabled onClick={onClick}>Disabled</Button>)
+    const btn = screen.getByRole('button')
+    expect(btn).toBeDisabled()
+    await userEvent.click(btn)
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('applies variant classes', () => {
+    render(<Button variant="destructive">Delete</Button>)
+    expect(screen.getByRole('button')).toHaveClass('bg-destructive')
+  })
+
+  it('applies size classes', () => {
+    render(<Button size="lg">Large</Button>)
+    expect(screen.getByRole('button')).toHaveClass('h-12')
+  })
+
+  it('merges custom className', () => {
+    render(<Button className="custom-class">Btn</Button>)
+    expect(screen.getByRole('button')).toHaveClass('custom-class')
+  })
+})

--- a/src/components/atoms/__tests__/Card.test.tsx
+++ b/src/components/atoms/__tests__/Card.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Card } from '../Card'
+
+describe('Card', () => {
+  it('renders as a compound component', () => {
+    render(
+      <Card>
+        <Card.Header>
+          <Card.Title>Title</Card.Title>
+          <Card.Description>Description</Card.Description>
+        </Card.Header>
+        <Card.Content>Content</Card.Content>
+        <Card.Footer>Footer</Card.Footer>
+      </Card>
+    )
+    expect(screen.getByText('Title')).toBeInTheDocument()
+    expect(screen.getByText('Description')).toBeInTheDocument()
+    expect(screen.getByText('Content')).toBeInTheDocument()
+    expect(screen.getByText('Footer')).toBeInTheDocument()
+  })
+
+  it('Card.Title renders as h3', () => {
+    render(<Card><Card.Header><Card.Title>Hello</Card.Title></Card.Header></Card>)
+    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('Hello')
+  })
+
+  it('merges custom className on root', () => {
+    render(<Card className="custom"><Card.Content>x</Card.Content></Card>)
+    const card = screen.getByText('x').closest('.rounded-2xl')
+    expect(card).toHaveClass('custom')
+  })
+})

--- a/src/components/atoms/__tests__/Checkbox.test.tsx
+++ b/src/components/atoms/__tests__/Checkbox.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Checkbox } from '../Checkbox'
+
+describe('Checkbox', () => {
+  it('renders unchecked by default', () => {
+    render(<Checkbox aria-label="Check" />)
+    expect(screen.getByRole('checkbox')).toHaveAttribute('data-state', 'unchecked')
+  })
+
+  it('renders checked when defaultChecked', () => {
+    render(<Checkbox defaultChecked aria-label="Check" />)
+    expect(screen.getByRole('checkbox')).toHaveAttribute('data-state', 'checked')
+  })
+
+  it('toggles on click', async () => {
+    render(<Checkbox aria-label="Check" />)
+    const cb = screen.getByRole('checkbox')
+    await userEvent.click(cb)
+    expect(cb).toHaveAttribute('data-state', 'checked')
+  })
+
+  it('calls onCheckedChange', async () => {
+    const onCheckedChange = vi.fn()
+    render(<Checkbox aria-label="Check" onCheckedChange={onCheckedChange} />)
+    await userEvent.click(screen.getByRole('checkbox'))
+    expect(onCheckedChange).toHaveBeenCalledWith(true)
+  })
+
+  it('does not toggle when disabled', async () => {
+    const onCheckedChange = vi.fn()
+    render(<Checkbox disabled aria-label="Check" onCheckedChange={onCheckedChange} />)
+    await userEvent.click(screen.getByRole('checkbox'))
+    expect(onCheckedChange).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/atoms/__tests__/Input.test.tsx
+++ b/src/components/atoms/__tests__/Input.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Input } from '../Input'
+
+describe('Input', () => {
+  it('renders with placeholder', () => {
+    render(<Input placeholder="Search…" />)
+    expect(screen.getByPlaceholderText('Search…')).toBeInTheDocument()
+  })
+
+  it('accepts user input', async () => {
+    render(<Input placeholder="Type here" />)
+    const input = screen.getByPlaceholderText('Type here')
+    await userEvent.type(input, 'hello')
+    expect(input).toHaveValue('hello')
+  })
+
+  it('is disabled when disabled prop is set', () => {
+    render(<Input disabled placeholder="Disabled" />)
+    expect(screen.getByPlaceholderText('Disabled')).toBeDisabled()
+  })
+
+  it('calls onChange', async () => {
+    const onChange = vi.fn()
+    render(<Input placeholder="x" onChange={onChange} />)
+    await userEvent.type(screen.getByPlaceholderText('x'), 'a')
+    expect(onChange).toHaveBeenCalled()
+  })
+
+  it('applies aria-invalid for invalid state', () => {
+    render(<Input aria-invalid="true" placeholder="bad" />)
+    expect(screen.getByPlaceholderText('bad')).toHaveAttribute('aria-invalid', 'true')
+  })
+})

--- a/src/components/atoms/__tests__/Switch.test.tsx
+++ b/src/components/atoms/__tests__/Switch.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Switch } from '../Switch'
+
+describe('Switch', () => {
+  it('renders unchecked by default', () => {
+    render(<Switch aria-label="Toggle" />)
+    expect(screen.getByRole('switch')).toHaveAttribute('data-state', 'unchecked')
+  })
+
+  it('renders checked when defaultChecked', () => {
+    render(<Switch defaultChecked aria-label="Toggle" />)
+    expect(screen.getByRole('switch')).toHaveAttribute('data-state', 'checked')
+  })
+
+  it('toggles on click', async () => {
+    render(<Switch aria-label="Toggle" />)
+    const sw = screen.getByRole('switch')
+    expect(sw).toHaveAttribute('data-state', 'unchecked')
+    await userEvent.click(sw)
+    expect(sw).toHaveAttribute('data-state', 'checked')
+  })
+
+  it('calls onCheckedChange', async () => {
+    const onCheckedChange = vi.fn()
+    render(<Switch aria-label="Toggle" onCheckedChange={onCheckedChange} />)
+    await userEvent.click(screen.getByRole('switch'))
+    expect(onCheckedChange).toHaveBeenCalledWith(true)
+  })
+
+  it('is disabled when disabled prop is set', async () => {
+    const onCheckedChange = vi.fn()
+    render(<Switch disabled aria-label="Toggle" onCheckedChange={onCheckedChange} />)
+    const sw = screen.getByRole('switch')
+    expect(sw).toBeDisabled()
+    await userEvent.click(sw)
+    expect(onCheckedChange).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/atoms/__tests__/Tag.test.tsx
+++ b/src/components/atoms/__tests__/Tag.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Tag } from '../Tag'
+
+describe('Tag', () => {
+  it('renders children', () => {
+    render(<Tag>React</Tag>)
+    expect(screen.getByText('React')).toBeInTheDocument()
+  })
+
+  it('does not show dismiss button when onDismiss is not provided', () => {
+    render(<Tag>TypeScript</Tag>)
+    expect(screen.queryByRole('button', { name: 'Remove tag' })).not.toBeInTheDocument()
+  })
+
+  it('shows dismiss button when onDismiss is provided', () => {
+    render(<Tag onDismiss={vi.fn()}>Tailwind</Tag>)
+    expect(screen.getByRole('button', { name: 'Remove tag' })).toBeInTheDocument()
+  })
+
+  it('calls onDismiss when dismiss button is clicked', async () => {
+    const onDismiss = vi.fn()
+    render(<Tag onDismiss={onDismiss}>Vue</Tag>)
+    await userEvent.click(screen.getByRole('button', { name: 'Remove tag' }))
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('applies primary variant', () => {
+    render(<Tag variant="primary">Next.js</Tag>)
+    expect(screen.getByText('Next.js')).toHaveClass('bg-primary/10')
+  })
+})

--- a/src/components/molecules/CodeBlock.tsx
+++ b/src/components/molecules/CodeBlock.tsx
@@ -1,35 +1,43 @@
-import { clsx, type ClassValue } from 'clsx';
-import { twMerge } from 'tailwind-merge';
+import * as React from "react"
+import { Check, Copy } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard"
+import { Button } from "@/components/atoms/Button"
 
-function cn(...inputs: ClassValue[]) {
-    return twMerge(clsx(inputs));
+export interface CodeBlockProps {
+  children: React.ReactNode
+  className?: string
+  language?: string
 }
 
-import { Check, Copy } from 'lucide-react';
-import { useCopyToClipboard } from '../../hooks/useCopyToClipboard';
-import { Button } from '@/components/atoms/Button';
-import { Icon } from '@/components/atoms/Icon';
+export function CodeBlock({ className, language, children }: CodeBlockProps) {
+  const { isCopied, copyToClipboard } = useCopyToClipboard()
+  const textToCopy = typeof children === "string" ? children : ""
 
-export function CodeBlock({ className, children }: { className?: string, children: React.ReactNode }) {
-    const { isCopied, copyToClipboard } = useCopyToClipboard();
-    const textToCopy = typeof children === 'string' ? children : '';
-
-    return (
-        <div className="relative group">
-            <pre className={cn("font-mono text-xs text-emerald-400 bg-black/50 p-4 rounded-md overflow-x-auto", className)}>
-                <code>{children}</code>
-            </pre>
-            {textToCopy && (
-                <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => copyToClipboard(textToCopy)}
-                    className="absolute top-2 right-2 h-8 w-8 text-slate-400 opacity-0 group-hover:opacity-100 transition-opacity hover:text-white hover:bg-slate-800"
-                    title="Copy code"
-                >
-                    {isCopied ? <Icon icon={Check} size={14} className="text-emerald-500" /> : <Icon icon={Copy} size={14} />}
-                </Button>
-            )}
+  return (
+    <div className="relative group rounded-2xl overflow-hidden border border-border bg-muted">
+      {language && (
+        <div className="flex items-center justify-between px-4 pt-3 pb-2 border-b border-border">
+          <span className="text-xs font-mono text-muted-foreground">{language}</span>
         </div>
-    );
+      )}
+      <pre className={cn("font-mono text-sm text-foreground p-4 overflow-x-auto leading-relaxed", className)}>
+        <code>{children}</code>
+      </pre>
+      {textToCopy && (
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => copyToClipboard(textToCopy)}
+          className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity"
+          title="Copy code"
+        >
+          {isCopied
+            ? <Check className="h-3.5 w-3.5 text-success" />
+            : <Copy className="h-3.5 w-3.5" />
+          }
+        </Button>
+      )}
+    </div>
+  )
 }

--- a/src/components/molecules/DropdownMenu.tsx
+++ b/src/components/molecules/DropdownMenu.tsx
@@ -1,201 +1,205 @@
 import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import { Check, ChevronRight, Circle } from "lucide-react"
-
 import { cn } from "@/lib/utils"
-import { labelVariants } from "@/components/atoms/Label"
-import { Icon } from "@/components/atoms/Icon"
 
-const DropdownMenu = DropdownMenuPrimitive.Root
-
+const DropdownMenuRoot = DropdownMenuPrimitive.Root
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
-
 const DropdownMenuGroup = DropdownMenuPrimitive.Group
-
 const DropdownMenuPortal = DropdownMenuPrimitive.Portal
-
 const DropdownMenuSub = DropdownMenuPrimitive.Sub
-
 const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
 
 const DropdownMenuSubTrigger = React.forwardRef<
-    React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
-    React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
-        inset?: boolean
-    }
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & { inset?: boolean }
 >(({ className, inset, children, ...props }, ref) => (
-    <DropdownMenuPrimitive.SubTrigger
-        ref={ref}
-        className={cn(
-            "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent",
-            inset && "pl-8",
-            className
-        )}
-        {...props}
-    >
-        {children}
-        <Icon icon={ChevronRight} className="ml-auto h-4 w-4" />
-    </DropdownMenuPrimitive.SubTrigger>
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center rounded-lg px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent data-[state=open]:bg-accent",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-4 w-4 text-muted-foreground" />
+  </DropdownMenuPrimitive.SubTrigger>
 ))
-DropdownMenuSubTrigger.displayName =
-    DropdownMenuPrimitive.SubTrigger.displayName
+DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName
 
 const DropdownMenuSubContent = React.forwardRef<
-    React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
-    React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
 >(({ className, ...props }, ref) => (
-    <DropdownMenuPrimitive.SubContent
-        ref={ref}
-        className={cn(
-            "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-            className
-        )}
-        {...props}
-    />
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-2xl border border-border bg-popover p-1 text-popover-foreground shadow-lg",
+      "data-[state=open]:animate-in data-[state=closed]:animate-out",
+      "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+      className
+    )}
+    {...props}
+  />
 ))
-DropdownMenuSubContent.displayName =
-    DropdownMenuPrimitive.SubContent.displayName
+DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName
 
 const DropdownMenuContent = React.forwardRef<
-    React.ElementRef<typeof DropdownMenuPrimitive.Content>,
-    React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-    <DropdownMenuPrimitive.Portal>
-        <DropdownMenuPrimitive.Content
-            ref={ref}
-            sideOffset={sideOffset}
-            className={cn(
-                "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-white p-1 text-gray-950 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-                className
-            )}
-            {...props}
-        />
-    </DropdownMenuPrimitive.Portal>
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 6, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 min-w-[10rem] overflow-hidden rounded-2xl border border-border bg-popover p-1 text-popover-foreground shadow-lg",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
+        "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
 ))
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
 
 const DropdownMenuItem = React.forwardRef<
-    React.ElementRef<typeof DropdownMenuPrimitive.Item>,
-    React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
-        inset?: boolean
-    }
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & { inset?: boolean }
 >(({ className, inset, ...props }, ref) => (
-    <DropdownMenuPrimitive.Item
-        ref={ref}
-        className={cn(
-            "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-gray-100 focus:text-gray-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-            inset && "pl-8",
-            className
-        )}
-        {...props}
-    />
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-lg px-2 py-1.5 text-sm outline-none transition-colors",
+      "focus:bg-accent focus:text-accent-foreground",
+      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
 ))
 DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
 
 const DropdownMenuCheckboxItem = React.forwardRef<
-    React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
-    React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
 >(({ className, children, checked, ...props }, ref) => (
-    <DropdownMenuPrimitive.CheckboxItem
-        ref={ref}
-        className={cn(
-            "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-            className
-        )}
-        checked={checked}
-        {...props}
-    >
-        <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-            <DropdownMenuPrimitive.ItemIndicator>
-                <Icon icon={Check} className="h-4 w-4" />
-            </DropdownMenuPrimitive.ItemIndicator>
-        </span>
-        {children}
-    </DropdownMenuPrimitive.CheckboxItem>
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-lg py-1.5 pl-8 pr-2 text-sm outline-none transition-colors",
+      "focus:bg-accent focus:text-accent-foreground",
+      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4 text-primary" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
 ))
-DropdownMenuCheckboxItem.displayName =
-    DropdownMenuPrimitive.CheckboxItem.displayName
+DropdownMenuCheckboxItem.displayName = DropdownMenuPrimitive.CheckboxItem.displayName
 
 const DropdownMenuRadioItem = React.forwardRef<
-    React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
-    React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
 >(({ className, children, ...props }, ref) => (
-    <DropdownMenuPrimitive.RadioItem
-        ref={ref}
-        className={cn(
-            "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-            className
-        )}
-        {...props}
-    >
-        <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-            <DropdownMenuPrimitive.ItemIndicator>
-                <Icon icon={Circle} className="h-2 w-2 fill-current" />
-            </DropdownMenuPrimitive.ItemIndicator>
-        </span>
-        {children}
-    </DropdownMenuPrimitive.RadioItem>
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-lg py-1.5 pl-8 pr-2 text-sm outline-none transition-colors",
+      "focus:bg-accent focus:text-accent-foreground",
+      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-primary text-primary" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
 ))
 DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName
 
 const DropdownMenuLabel = React.forwardRef<
-    React.ElementRef<typeof DropdownMenuPrimitive.Label>,
-    React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
-        inset?: boolean
-    }
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & { inset?: boolean }
 >(({ className, inset, ...props }, ref) => (
-    <DropdownMenuPrimitive.Label
-        ref={ref}
-        className={cn(
-            "px-2 py-1.5",
-            labelVariants(),
-            inset && "pl-8",
-            className
-        )}
-        {...props}
-    />
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      "px-2 py-1.5 text-xs font-semibold text-muted-foreground",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
 ))
 DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
 
 const DropdownMenuSeparator = React.forwardRef<
-    React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
-    React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
 >(({ className, ...props }, ref) => (
-    <DropdownMenuPrimitive.Separator
-        ref={ref}
-        className={cn("-mx-1 my-1 h-px bg-gray-100", className)}
-        {...props}
-    />
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-border", className)}
+    {...props}
+  />
 ))
 DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
 
-const DropdownMenuShortcut = ({
-    className,
-    ...props
-}: React.HTMLAttributes<HTMLSpanElement>) => {
-    return (
-        <span
-            className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
-            {...props}
-        />
-    )
-}
+const DropdownMenuShortcut = ({ className, ...props }: React.HTMLAttributes<HTMLSpanElement>) => (
+  <span className={cn("ml-auto text-xs tracking-widest text-muted-foreground", className)} {...props} />
+)
 DropdownMenuShortcut.displayName = "DropdownMenuShortcut"
 
+const DropdownMenu = Object.assign(DropdownMenuRoot, {
+  Trigger: DropdownMenuTrigger,
+  Content: DropdownMenuContent,
+  Item: DropdownMenuItem,
+  CheckboxItem: DropdownMenuCheckboxItem,
+  RadioItem: DropdownMenuRadioItem,
+  Label: DropdownMenuLabel,
+  Separator: DropdownMenuSeparator,
+  Shortcut: DropdownMenuShortcut,
+  Group: DropdownMenuGroup,
+  Sub: DropdownMenuSub,
+  SubTrigger: DropdownMenuSubTrigger,
+  SubContent: DropdownMenuSubContent,
+  RadioGroup: DropdownMenuRadioGroup,
+})
+
 export {
-    DropdownMenu,
-    DropdownMenuTrigger,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuCheckboxItem,
-    DropdownMenuRadioItem,
-    DropdownMenuLabel,
-    DropdownMenuSeparator,
-    DropdownMenuShortcut,
-    DropdownMenuGroup,
-    DropdownMenuPortal,
-    DropdownMenuSub,
-    DropdownMenuSubContent,
-    DropdownMenuSubTrigger,
-    DropdownMenuRadioGroup,
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
 }

--- a/src/components/molecules/Form.tsx
+++ b/src/components/molecules/Form.tsx
@@ -1,0 +1,169 @@
+import * as React from "react"
+import {
+  Controller,
+  FormProvider,
+  useFormContext,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
+} from "react-hook-form"
+import { Label } from "@/components/atoms/Label"
+import { cn } from "@/lib/utils"
+
+/* ─── Context ─── */
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = { name: TName }
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue
+)
+
+type FormItemContextValue = { id: string }
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue
+)
+
+/* ─── useFormField ─── */
+export function useFormField() {
+  const fieldContext = React.useContext(FormFieldContext)
+  const itemContext = React.useContext(FormItemContext)
+  const { getFieldState, formState } = useFormContext()
+
+  const fieldState = getFieldState(fieldContext.name, formState)
+
+  if (!fieldContext) {
+    throw new Error("useFormField must be used within <Form.Field>")
+  }
+
+  const { id } = itemContext
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  }
+}
+
+/* ─── Form (root) ─── */
+const FormRoot = FormProvider
+
+/* ─── Form.Field ─── */
+function FormField<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({ ...props }: ControllerProps<TFieldValues, TName>) {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  )
+}
+FormField.displayName = "Form.Field"
+
+/* ─── Form.Item ─── */
+const FormItem = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => {
+    const id = React.useId()
+    return (
+      <FormItemContext.Provider value={{ id }}>
+        <div ref={ref} className={cn("grid gap-1.5", className)} {...props} />
+      </FormItemContext.Provider>
+    )
+  }
+)
+FormItem.displayName = "Form.Item"
+
+/* ─── Form.Label ─── */
+const FormLabel = React.forwardRef<
+  React.ElementRef<typeof Label>,
+  React.ComponentPropsWithoutRef<typeof Label>
+>(({ className, ...props }, ref) => {
+  const { error, formItemId } = useFormField()
+  return (
+    <Label
+      ref={ref}
+      className={cn(error && "text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  )
+})
+FormLabel.displayName = "Form.Label"
+
+/* ─── Form.Control ─── */
+const FormControl = ({ children }: { children: React.ReactElement }) => {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+  return React.cloneElement(children, {
+    id: formItemId,
+    "aria-describedby": !error
+      ? formDescriptionId
+      : `${formDescriptionId} ${formMessageId}`,
+    "aria-invalid": !!error,
+  } as React.HTMLAttributes<HTMLElement>)
+}
+FormControl.displayName = "Form.Control"
+
+/* ─── Form.Description ─── */
+const FormDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => {
+  const { formDescriptionId } = useFormField()
+  return (
+    <p
+      ref={ref}
+      id={formDescriptionId}
+      className={cn("text-xs text-muted-foreground", className)}
+      {...props}
+    />
+  )
+})
+FormDescription.displayName = "Form.Description"
+
+/* ─── Form.Message ─── */
+const FormMessage = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+  const { error, formMessageId } = useFormField()
+  const body = error ? String(error?.message ?? "") : children
+
+  if (!body) return null
+
+  return (
+    <p
+      ref={ref}
+      id={formMessageId}
+      className={cn("text-xs font-medium text-destructive", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  )
+})
+FormMessage.displayName = "Form.Message"
+
+/* ─── Compound export ─── */
+const Form = Object.assign(FormRoot, {
+  Field: FormField,
+  Item: FormItem,
+  Label: FormLabel,
+  Control: FormControl,
+  Description: FormDescription,
+  Message: FormMessage,
+})
+
+export {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+}

--- a/src/components/molecules/Table.tsx
+++ b/src/components/molecules/Table.tsx
@@ -1,12 +1,11 @@
 import * as React from "react"
-
 import { cn } from "@/lib/utils"
 
-const Table = React.forwardRef<
+const TableRoot = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
+  <div className="relative w-full overflow-auto rounded-2xl border border-border">
     <table
       ref={ref}
       className={cn("w-full caption-bottom text-sm", className)}
@@ -14,15 +13,19 @@ const Table = React.forwardRef<
     />
   </div>
 ))
-Table.displayName = "Table"
+TableRoot.displayName = "Table"
 
 const TableHeader = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+  <thead
+    ref={ref}
+    className={cn("bg-muted/50 [&_tr]:border-b", className)}
+    {...props}
+  />
 ))
-TableHeader.displayName = "TableHeader"
+TableHeader.displayName = "Table.Header"
 
 const TableBody = React.forwardRef<
   HTMLTableSectionElement,
@@ -34,7 +37,7 @@ const TableBody = React.forwardRef<
     {...props}
   />
 ))
-TableBody.displayName = "TableBody"
+TableBody.displayName = "Table.Body"
 
 const TableFooter = React.forwardRef<
   HTMLTableSectionElement,
@@ -42,14 +45,11 @@ const TableFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <tfoot
     ref={ref}
-    className={cn(
-      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
-      className
-    )}
+    className={cn("border-t bg-muted/50 font-medium [&>tr]:last:border-b-0", className)}
     {...props}
   />
 ))
-TableFooter.displayName = "TableFooter"
+TableFooter.displayName = "Table.Footer"
 
 const TableRow = React.forwardRef<
   HTMLTableRowElement,
@@ -64,7 +64,7 @@ const TableRow = React.forwardRef<
     {...props}
   />
 ))
-TableRow.displayName = "TableRow"
+TableRow.displayName = "Table.Row"
 
 const TableHead = React.forwardRef<
   HTMLTableCellElement,
@@ -73,13 +73,13 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      "h-11 px-4 text-left align-middle text-xs font-semibold text-muted-foreground uppercase tracking-wide [&:has([role=checkbox])]:pr-0",
       className
     )}
     {...props}
   />
 ))
-TableHead.displayName = "TableHead"
+TableHead.displayName = "Table.Head"
 
 const TableCell = React.forwardRef<
   HTMLTableCellElement,
@@ -87,11 +87,11 @@ const TableCell = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <td
     ref={ref}
-    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    className={cn("px-4 py-3 align-middle [&:has([role=checkbox])]:pr-0", className)}
     {...props}
   />
 ))
-TableCell.displayName = "TableCell"
+TableCell.displayName = "Table.Cell"
 
 const TableCaption = React.forwardRef<
   HTMLTableCaptionElement,
@@ -99,19 +99,29 @@ const TableCaption = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <caption
     ref={ref}
-    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    className={cn("py-3 text-sm text-muted-foreground", className)}
     {...props}
   />
 ))
-TableCaption.displayName = "TableCaption"
+TableCaption.displayName = "Table.Caption"
+
+const Table = Object.assign(TableRoot, {
+  Header: TableHeader,
+  Body: TableBody,
+  Footer: TableFooter,
+  Row: TableRow,
+  Head: TableHead,
+  Cell: TableCell,
+  Caption: TableCaption,
+})
 
 export {
   Table,
   TableHeader,
   TableBody,
   TableFooter,
-  TableHead,
   TableRow,
+  TableHead,
   TableCell,
   TableCaption,
 }

--- a/src/components/molecules/Tabs.tsx
+++ b/src/components/molecules/Tabs.tsx
@@ -1,59 +1,63 @@
-import { useState, createContext, useContext } from 'react';
-import { clsx, type ClassValue } from 'clsx';
-import { twMerge } from 'tailwind-merge';
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+import { cn } from "@/lib/utils"
 
-function cn(...inputs: ClassValue[]) {
-    return twMerge(clsx(inputs));
-}
+const TabsRoot = TabsPrimitive.Root
 
-const TabsContext = createContext<{ value: string; setValue: (v: string) => void } | null>(null);
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex items-center gap-1 border-b border-border",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
 
-export function Tabs({ defaultValue, children, className }: { defaultValue: string, children: React.ReactNode, className?: string }) {
-    const [value, setValue] = useState(defaultValue);
-    return (
-        <TabsContext.Provider value={{ value, setValue }}>
-            <div className={cn("w-full", className)}>{children}</div>
-        </TabsContext.Provider>
-    );
-}
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap px-4 pb-3 pt-2 text-sm font-medium text-muted-foreground transition-all",
+      "border-b-2 border-transparent -mb-px",
+      "hover:text-foreground",
+      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "disabled:pointer-events-none disabled:opacity-50",
+      "data-[state=active]:border-primary data-[state=active]:text-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
 
-export function TabsList({ children, className }: { children: React.ReactNode, className?: string }) {
-    return (
-        <div className={cn("inline-flex h-10 items-center justify-center rounded-md bg-slate-900 p-1 text-slate-500", className)}>
-            {children}
-        </div>
-    );
-}
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
 
-export function TabsTrigger({ value, children, className }: { value: string, children: React.ReactNode, className?: string }) {
-    const context = useContext(TabsContext);
-    if (!context) throw new Error("TabsTrigger must be used within Tabs");
+const Tabs = Object.assign(TabsRoot, {
+  List: TabsList,
+  Trigger: TabsTrigger,
+  Content: TabsContent,
+})
 
-    const isActive = context.value === value;
-
-    return (
-        <button
-            onClick={() => context.setValue(value)}
-            className={cn(
-                "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
-                isActive ? "bg-slate-800 text-white shadow-sm" : "hover:bg-slate-800/50 hover:text-slate-300",
-                className
-            )}
-        >
-            {children}
-        </button>
-    );
-}
-
-export function TabsContent({ value, children, className }: { value: string, children: React.ReactNode, className?: string }) {
-    const context = useContext(TabsContext);
-    if (!context) throw new Error("TabsContent must be used within Tabs");
-
-    if (context.value !== value) return null;
-
-    return (
-        <div className={cn("mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2", className)}>
-            {children}
-        </div>
-    );
-}
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/src/components/molecules/__tests__/Form.test.tsx
+++ b/src/components/molecules/__tests__/Form.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useForm } from 'react-hook-form'
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '../Form'
+import { Input } from '@/components/atoms/Input'
+import { Button } from '@/components/atoms/Button'
+
+function LoginForm({ onSubmit = vi.fn() }: { onSubmit?: (data: unknown) => void }) {
+  const form = useForm({ defaultValues: { email: '' } })
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <FormField
+          control={form.control}
+          name="email"
+          rules={{ required: 'Email is required' }}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <Input placeholder="email" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit">Submit</Button>
+      </form>
+    </Form>
+  )
+}
+
+describe('Form', () => {
+  it('renders label and input', () => {
+    render(<LoginForm />)
+    expect(screen.getByLabelText('Email')).toBeInTheDocument()
+  })
+
+  it('shows validation error when submitted empty', async () => {
+    render(<LoginForm />)
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    await waitFor(() => {
+      expect(screen.getByText('Email is required')).toBeInTheDocument()
+    })
+  })
+
+  it('calls onSubmit with correct data when valid', async () => {
+    const onSubmit = vi.fn()
+    render(<LoginForm onSubmit={onSubmit} />)
+    await userEvent.type(screen.getByPlaceholderText('email'), 'test@example.com')
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith({ email: 'test@example.com' }, expect.anything())
+    })
+  })
+
+  it('links label htmlFor to input id via FormItem context', () => {
+    render(<LoginForm />)
+    const label = screen.getByText('Email')
+    const input = screen.getByPlaceholderText('email')
+    expect(label).toHaveAttribute('for', input.id)
+  })
+})

--- a/src/components/molecules/__tests__/Table.test.tsx
+++ b/src/components/molecules/__tests__/Table.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '../Table'
+
+function SampleTable() {
+  return (
+    <Table>
+      <Table.Header>
+        <Table.Row>
+          <Table.Head>Name</Table.Head>
+          <Table.Head>Role</Table.Head>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>Junseop</Table.Cell>
+          <Table.Cell>Frontend Engineer</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table>
+  )
+}
+
+describe('Table', () => {
+  it('renders headers', () => {
+    render(<SampleTable />)
+    expect(screen.getByText('Name')).toBeInTheDocument()
+    expect(screen.getByText('Role')).toBeInTheDocument()
+  })
+
+  it('renders body cells', () => {
+    render(<SampleTable />)
+    expect(screen.getByText('Junseop')).toBeInTheDocument()
+    expect(screen.getByText('Frontend Engineer')).toBeInTheDocument()
+  })
+
+  it('supports named exports (backward compat)', () => {
+    render(
+      <Table>
+        <TableHeader>
+          <TableRow><TableHead>Col</TableHead></TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow><TableCell>Val</TableCell></TableRow>
+        </TableBody>
+      </Table>
+    )
+    expect(screen.getByText('Col')).toBeInTheDocument()
+    expect(screen.getByText('Val')).toBeInTheDocument()
+  })
+})

--- a/src/components/molecules/__tests__/Tabs.test.tsx
+++ b/src/components/molecules/__tests__/Tabs.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '../Tabs'
+
+function renderTabs() {
+  return render(
+    <Tabs defaultValue="tab1">
+      <TabsList>
+        <TabsTrigger value="tab1">Tab 1</TabsTrigger>
+        <TabsTrigger value="tab2">Tab 2</TabsTrigger>
+        <TabsTrigger value="tab3" disabled>Tab 3</TabsTrigger>
+      </TabsList>
+      <TabsContent value="tab1">Content 1</TabsContent>
+      <TabsContent value="tab2">Content 2</TabsContent>
+      <TabsContent value="tab3">Content 3</TabsContent>
+    </Tabs>
+  )
+}
+
+describe('Tabs', () => {
+  it('renders default active tab content', () => {
+    renderTabs()
+    expect(screen.getByText('Content 1')).toBeInTheDocument()
+    expect(screen.queryByText('Content 2')).not.toBeInTheDocument()
+  })
+
+  it('switches content on trigger click', async () => {
+    renderTabs()
+    await userEvent.click(screen.getByRole('tab', { name: 'Tab 2' }))
+    expect(screen.getByText('Content 2')).toBeInTheDocument()
+    expect(screen.queryByText('Content 1')).not.toBeInTheDocument()
+  })
+
+  it('disabled tab cannot be clicked', async () => {
+    renderTabs()
+    const disabledTab = screen.getByRole('tab', { name: 'Tab 3' })
+    expect(disabledTab).toBeDisabled()
+  })
+
+  it('active trigger has correct aria-selected', () => {
+    renderTabs()
+    expect(screen.getByRole('tab', { name: 'Tab 1' })).toHaveAttribute('data-state', 'active')
+    expect(screen.getByRole('tab', { name: 'Tab 2' })).toHaveAttribute('data-state', 'inactive')
+  })
+
+  it('supports compound dot notation', () => {
+    render(
+      <Tabs defaultValue="a">
+        <Tabs.List><Tabs.Trigger value="a">A</Tabs.Trigger></Tabs.List>
+        <Tabs.Content value="a">Alpha</Tabs.Content>
+      </Tabs>
+    )
+    expect(screen.getByText('Alpha')).toBeInTheDocument()
+  })
+})

--- a/src/components/organisms/DataTable.tsx
+++ b/src/components/organisms/DataTable.tsx
@@ -1,3 +1,4 @@
+import * as React from "react"
 import {
   ColumnDef,
   flexRender,
@@ -6,33 +7,35 @@ import {
   getSortedRowModel,
   SortingState,
   useReactTable,
-} from "@tanstack/react-table";
-import { ArrowUpDown } from "lucide-react";
-import * as React from "react";
-import { Icon } from "@/components/atoms/Icon";
-
+} from "@tanstack/react-table"
+import { ArrowUpDown, Search } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { Input } from "@/components/atoms/Input"
+import { Button } from "@/components/atoms/Button"
 import {
   Table,
-  TableBody,
-  TableCell,
-  TableHead,
   TableHeader,
+  TableBody,
   TableRow,
-} from "@/components/molecules/Table";
-import { Input } from "@/components/atoms/Input";
-import { Button } from "@/components/atoms/Button";
+  TableHead,
+  TableCell,
+} from "@/components/molecules/Table"
 
-interface DataTableProps<TData, TValue> {
-  columns: ColumnDef<TData, TValue>[];
-  data: TData[];
+export interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[]
+  data: TData[]
+  filterPlaceholder?: string
+  className?: string
 }
 
 export function DataTable<TData, TValue>({
   columns,
   data,
+  filterPlaceholder = "Filter…",
+  className,
 }: DataTableProps<TData, TValue>) {
-  const [sorting, setSorting] = React.useState<SortingState>([]);
-  const [globalFilter, setGlobalFilter] = React.useState("");
+  const [sorting, setSorting] = React.useState<SortingState>([])
+  const [globalFilter, setGlobalFilter] = React.useState("")
 
   const table = useReactTable({
     data,
@@ -42,82 +45,65 @@ export function DataTable<TData, TValue>({
     getFilteredRowModel: getFilteredRowModel(),
     onSortingChange: setSorting,
     onGlobalFilterChange: setGlobalFilter,
-    state: {
-      sorting,
-      globalFilter,
-    },
-  });
+    state: { sorting, globalFilter },
+  })
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center">
+    <div className={cn("space-y-4", className)}>
+      <div className="relative flex items-center max-w-sm">
+        <Search className="absolute left-3 h-4 w-4 text-muted-foreground pointer-events-none" />
         <Input
-          placeholder="필터..."
+          placeholder={filterPlaceholder}
           value={globalFilter ?? ""}
-          onChange={(event) => setGlobalFilter(event.target.value)}
-          className="max-w-sm"
+          onChange={(e) => setGlobalFilter(e.target.value)}
+          className="pl-9"
         />
       </div>
-      <div className="rounded-md border">
-        <Table>
-          <TableHeader>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id}>
-                {headerGroup.headers.map((header) => {
-                  return (
-                    <TableHead key={header.id}>
-                      {header.isPlaceholder
-                        ? null
-                        : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext()
-                        )}
+      <Table>
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <TableHead key={header.id}>
+                  {header.isPlaceholder ? null : (
+                    <div className="flex items-center gap-1">
+                      {flexRender(header.column.columnDef.header, header.getContext())}
                       {header.column.getCanSort() && (
                         <Button
                           variant="ghost"
-                          size="sm"
+                          size="icon-sm"
                           onClick={() => header.column.toggleSorting(header.column.getIsSorted() === "asc")}
-                          className="-ml-3 h-8 data-[state=open]:bg-accent"
                         >
-                          <Icon icon={ArrowUpDown} className="ml-2 h-4 w-4" />
+                          <ArrowUpDown className="h-3.5 w-3.5" />
                         </Button>
                       )}
-                    </TableHead>
-                  );
-                })}
+                    </div>
+                  )}
+                </TableHead>
+              ))}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {table.getRowModel().rows?.length ? (
+            table.getRowModel().rows.map((row) => (
+              <TableRow key={row.id} data-state={row.getIsSelected() && "selected"}>
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
               </TableRow>
-            ))}
-          </TableHeader>
-          <TableBody>
-            {table.getRowModel().rows?.length ? (
-              table.getRowModel().rows.map((row) => (
-                <TableRow
-                  key={row.id}
-                  data-state={row.getIsSelected() && "selected"}
-                >
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext()
-                      )}
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))
-            ) : (
-              <TableRow>
-                <TableCell
-                  colSpan={columns.length}
-                  className="h-24 text-center"
-                >
-                  결과가 없습니다.
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
-      </div>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell colSpan={columns.length} className="h-24 text-center text-muted-foreground">
+                No results.
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
     </div>
-  );
+  )
 }

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -1,61 +1,95 @@
-import { Bell, User, Search } from 'lucide-react';
-import { Input } from '@/components/atoms/Input';
-import { Button } from '@/components/atoms/Button';
-import { Icon } from '@/components/atoms/Icon';
+import * as React from "react"
+import { cn } from "@/lib/utils"
 
-export interface HeaderProps {
-    user?: {
-        name: string;
-        role?: string;
-        avatarUrl?: string; // Optional: meant for future use if we add avatar image support
-    };
-    onSearch?: (query: string) => void;
-    searchPlaceholder?: string;
-    onNotificationClick?: () => void;
+/* ─── Context ─── */
+type HeaderContextValue = Record<string, never>
+const HeaderContext = React.createContext<HeaderContextValue>({})
+
+/* ─── Root ─── */
+const HeaderRoot = React.forwardRef<HTMLElement, React.HTMLAttributes<HTMLElement>>(
+  ({ className, ...props }, ref) => (
+    <HeaderContext.Provider value={{}}>
+      <header
+        ref={ref}
+        className={cn(
+          "sticky top-0 z-50 flex h-14 items-center gap-4 border-b border-border/50",
+          "bg-background/80 backdrop-blur-xl backdrop-saturate-150 px-6",
+          className
+        )}
+        {...props}
+      />
+    </HeaderContext.Provider>
+  )
+)
+HeaderRoot.displayName = "Header"
+
+/* ─── Brand ─── */
+const HeaderBrand = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("flex items-center gap-2 font-semibold text-foreground shrink-0", className)}
+      {...props}
+    />
+  )
+)
+HeaderBrand.displayName = "Header.Brand"
+
+/* ─── Nav ─── */
+const HeaderNav = React.forwardRef<HTMLElement, React.HTMLAttributes<HTMLElement>>(
+  ({ className, ...props }, ref) => (
+    <nav
+      ref={ref}
+      className={cn("flex items-center gap-1 flex-1", className)}
+      {...props}
+    />
+  )
+)
+HeaderNav.displayName = "Header.Nav"
+
+/* ─── NavItem ─── */
+export interface HeaderNavItemProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  active?: boolean
+  asChild?: boolean
 }
 
-export function Header({
-    user = { name: '게스트', role: 'Guest' },
-    onSearch,
-    searchPlaceholder = "검색...",
-    onNotificationClick
-}: HeaderProps) {
-    return (
-        <header className="sticky top-0 z-30 flex h-16 items-center gap-x-4 border-b border-slate-800 bg-slate-950/80 backdrop-blur px-6 shadow-sm">
-            <div className="flex flex-1 gap-x-4 self-stretch lg:gap-x-6">
-                <div className="relative flex flex-1 items-center">
-                    <Icon icon={Search} className="absolute left-2 h-4 w-4 text-slate-500 z-10" />
-                    <Input
-                        type="text"
-                        placeholder={searchPlaceholder}
-                        className="w-64 pl-8 bg-slate-900 border-slate-800 text-white placeholder:text-slate-500"
-                        onChange={(e) => onSearch?.(e.target.value)}
-                    />
-                </div>
-                <div className="flex items-center gap-x-4 lg:gap-x-6">
-                    <Button
-                        variant="ghost"
-                        size="icon"
-                        className="-m-2.5 p-2.5 text-slate-400 hover:text-white"
-                        onClick={onNotificationClick}
-                    >
-                        <span className="sr-only">알림 보기</span>
-                        <Icon icon={Bell} className="h-5 w-5" aria-hidden="true" />
-                    </Button>
+const HeaderNavItem = React.forwardRef<HTMLAnchorElement, HeaderNavItemProps>(
+  ({ className, active, children, ...props }, ref) => (
+    <a
+      ref={ref}
+      className={cn(
+        "px-3 py-1.5 rounded-lg text-sm font-medium transition-colors",
+        active
+          ? "bg-accent text-foreground"
+          : "text-muted-foreground hover:text-foreground hover:bg-accent",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </a>
+  )
+)
+HeaderNavItem.displayName = "Header.NavItem"
 
-                    <div className="h-6 w-px bg-slate-800" aria-hidden="true" />
+/* ─── Actions ─── */
+const HeaderActions = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("flex items-center gap-2 ml-auto shrink-0", className)}
+      {...props}
+    />
+  )
+)
+HeaderActions.displayName = "Header.Actions"
 
-                    <div className="flex items-center gap-x-3">
-                        <div className="flex flex-col items-end hidden md:flex">
-                            <span className="text-sm font-semibold text-white">{user.name}</span>
-                            <span className="text-xs text-slate-500">{user.role}</span>
-                        </div>
-                        <div className="h-8 w-8 rounded-full bg-slate-800 flex items-center justify-center border border-slate-700">
-                            <Icon icon={User} className="h-4 w-4 text-slate-400" />
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </header>
-    );
-}
+/* ─── Compound ─── */
+const Header = Object.assign(HeaderRoot, {
+  Brand: HeaderBrand,
+  Nav: HeaderNav,
+  NavItem: HeaderNavItem,
+  Actions: HeaderActions,
+})
+
+export { Header }

--- a/src/components/organisms/Sidebar.tsx
+++ b/src/components/organisms/Sidebar.tsx
@@ -1,78 +1,125 @@
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
-import { TrendingUp, LogOut, LucideIcon } from 'lucide-react';
-import { Button } from '@/components/atoms/Button';
-import { Icon } from '@/components/atoms/Icon';
-import { clsx, type ClassValue } from 'clsx';
-import { twMerge } from 'tailwind-merge';
+import * as React from "react"
+import { LucideIcon } from "lucide-react"
+import { cn } from "@/lib/utils"
 
-function cn(...inputs: ClassValue[]) {
-    return twMerge(clsx(inputs));
+/* ─── Context ─── */
+type SidebarContextValue = { collapsed: boolean; toggle: () => void }
+const SidebarContext = React.createContext<SidebarContextValue>({
+  collapsed: false,
+  toggle: () => {},
+})
+
+export function useSidebar() {
+  return React.useContext(SidebarContext)
 }
 
-export interface SidebarMenuItem {
-    name: string;
-    icon: LucideIcon;
-    href: string;
+/* ─── Root ─── */
+interface SidebarRootProps extends React.HTMLAttributes<HTMLElement> {
+  defaultCollapsed?: boolean
 }
 
-export interface SidebarProps {
-    menuItems: SidebarMenuItem[];
-    onSignOut?: () => void;
-    title?: string;
-    logo?: LucideIcon;
-}
-
-export function Sidebar({ menuItems, onSignOut, title = "앱 이름", logo: Logo = TrendingUp }: SidebarProps) {
-    const pathname = usePathname();
-
-    const handleSignOut = () => {
-        if (onSignOut) {
-            onSignOut();
-        } else {
-            // Default behavior or keeping existing one if passed
-            window.location.href = '/login';
-        }
-    };
+const SidebarRoot = React.forwardRef<HTMLElement, SidebarRootProps>(
+  ({ className, defaultCollapsed = false, children, ...props }, ref) => {
+    const [collapsed, setCollapsed] = React.useState(defaultCollapsed)
 
     return (
-        <aside className="fixed left-0 top-0 z-40 h-screen w-64 border-r border-slate-800 bg-slate-950 text-slate-300">
-            <div className="flex h-16 items-center px-6 border-b border-slate-800">
-                <Icon icon={Logo} className="h-6 w-6 text-blue-500 mr-2" />
-                <span className="text-lg font-bold text-white tracking-tight">{title}</span>
-            </div>
-            <div className="flex flex-col h-[calc(100vh-4rem)] justify-between py-4">
-                <nav className="space-y-1 px-3">
-                    {menuItems.map((item) => {
-                        const isActive = pathname === item.href;
-                        return (
-                            <Link
-                                key={item.href}
-                                href={item.href}
-                                className={cn(
-                                    "flex items-center px-3 py-2.5 rounded-lg text-sm font-medium transition-colors",
-                                    isActive
-                                        ? "bg-blue-600/10 text-blue-400"
-                                        : "hover:bg-slate-900 text-slate-400 hover:text-white"
-                                )}
-                            >
-                                <Icon icon={item.icon} className={cn("mr-3 h-5 w-5", isActive ? "text-blue-500" : "text-slate-500")} />
-                                {item.name}
-                            </Link>
-                        );
-                    })}
-                </nav>
-                <div className="px-3 border-t border-slate-800 pt-4">
-                    <Button
-                        variant="ghost"
-                        onClick={handleSignOut}
-                        className="w-full justify-start text-red-400 hover:text-red-300 hover:bg-red-500/10"
-                    >
-                        <Icon icon={LogOut} className="mr-3 h-5 w-5" />
-                        로그아웃
-                    </Button>
-                </div>
-            </div>
+      <SidebarContext.Provider value={{ collapsed, toggle: () => setCollapsed((v) => !v) }}>
+        <aside
+          ref={ref}
+          className={cn(
+            "fixed left-0 top-0 z-40 flex flex-col h-screen border-r border-border bg-background transition-all duration-300",
+            collapsed ? "w-16" : "w-64",
+            className
+          )}
+          {...props}
+        >
+          {children}
         </aside>
-    );
+      </SidebarContext.Provider>
+    )
+  }
+)
+SidebarRoot.displayName = "Sidebar"
+
+/* ─── Header ─── */
+const SidebarHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("flex h-14 items-center gap-2 border-b border-border px-4 shrink-0", className)}
+      {...props}
+    />
+  )
+)
+SidebarHeader.displayName = "Sidebar.Header"
+
+/* ─── Nav ─── */
+const SidebarNav = React.forwardRef<HTMLElement, React.HTMLAttributes<HTMLElement>>(
+  ({ className, ...props }, ref) => (
+    <nav
+      ref={ref}
+      className={cn("flex flex-col gap-1 flex-1 overflow-y-auto p-3", className)}
+      {...props}
+    />
+  )
+)
+SidebarNav.displayName = "Sidebar.Nav"
+
+/* ─── NavItem ─── */
+export interface SidebarNavItemProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  icon?: LucideIcon
+  active?: boolean
+  label: string
 }
+
+const SidebarNavItem = React.forwardRef<HTMLAnchorElement, SidebarNavItemProps>(
+  ({ className, icon: IconComponent, active, label, ...props }, ref) => {
+    const { collapsed } = useSidebar()
+
+    return (
+      <a
+        ref={ref}
+        title={collapsed ? label : undefined}
+        className={cn(
+          "flex items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium transition-colors",
+          active
+            ? "bg-primary/10 text-primary"
+            : "text-muted-foreground hover:bg-accent hover:text-foreground",
+          collapsed && "justify-center px-2",
+          className
+        )}
+        {...props}
+      >
+        {IconComponent && (
+          <IconComponent
+            className={cn("h-5 w-5 shrink-0", active && "text-primary")}
+          />
+        )}
+        {!collapsed && <span className="truncate">{label}</span>}
+      </a>
+    )
+  }
+)
+SidebarNavItem.displayName = "Sidebar.NavItem"
+
+/* ─── Footer ─── */
+const SidebarFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("border-t border-border p-3 shrink-0", className)}
+      {...props}
+    />
+  )
+)
+SidebarFooter.displayName = "Sidebar.Footer"
+
+/* ─── Compound ─── */
+const Sidebar = Object.assign(SidebarRoot, {
+  Header: SidebarHeader,
+  Nav: SidebarNav,
+  NavItem: SidebarNavItem,
+  Footer: SidebarFooter,
+})
+
+export { Sidebar }

--- a/src/components/organisms/__tests__/DataTable.test.tsx
+++ b/src/components/organisms/__tests__/DataTable.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ColumnDef } from '@tanstack/react-table'
+import { DataTable } from '../DataTable'
+
+type Person = { name: string; role: string }
+
+const columns: ColumnDef<Person>[] = [
+  { accessorKey: 'name', header: 'Name' },
+  { accessorKey: 'role', header: 'Role' },
+]
+
+const data: Person[] = [
+  { name: 'Junseop', role: 'Frontend' },
+  { name: 'Alice', role: 'Backend' },
+  { name: 'Bob', role: 'Design' },
+]
+
+describe('DataTable', () => {
+  it('renders all rows', () => {
+    render(<DataTable columns={columns} data={data} />)
+    expect(screen.getByText('Junseop')).toBeInTheDocument()
+    expect(screen.getByText('Alice')).toBeInTheDocument()
+    expect(screen.getByText('Bob')).toBeInTheDocument()
+  })
+
+  it('renders column headers', () => {
+    render(<DataTable columns={columns} data={data} />)
+    expect(screen.getByText('Name')).toBeInTheDocument()
+    expect(screen.getByText('Role')).toBeInTheDocument()
+  })
+
+  it('filters rows by global filter input', async () => {
+    render(<DataTable columns={columns} data={data} filterPlaceholder="Filter…" />)
+    const input = screen.getByPlaceholderText('Filter…')
+    await userEvent.type(input, 'Alice')
+    expect(screen.getByText('Alice')).toBeInTheDocument()
+    expect(screen.queryByText('Junseop')).not.toBeInTheDocument()
+  })
+
+  it('shows empty state when no results', async () => {
+    render(<DataTable columns={columns} data={data} />)
+    await userEvent.type(screen.getByRole('textbox'), 'zzzzz')
+    expect(screen.getByText('No results.')).toBeInTheDocument()
+  })
+
+  it('renders empty state when data is empty', () => {
+    render(<DataTable columns={columns} data={[]} />)
+    expect(screen.getByText('No results.')).toBeInTheDocument()
+  })
+})

--- a/src/components/organisms/__tests__/Header.test.tsx
+++ b/src/components/organisms/__tests__/Header.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Header } from '../Header'
+import { Button } from '@/components/atoms/Button'
+
+describe('Header', () => {
+  it('renders brand content', () => {
+    render(
+      <Header>
+        <Header.Brand>My App</Header.Brand>
+      </Header>
+    )
+    expect(screen.getByText('My App')).toBeInTheDocument()
+  })
+
+  it('renders nav items', () => {
+    render(
+      <Header>
+        <Header.Nav>
+          <Header.NavItem href="#">Home</Header.NavItem>
+          <Header.NavItem href="#">About</Header.NavItem>
+        </Header.Nav>
+      </Header>
+    )
+    expect(screen.getByText('Home')).toBeInTheDocument()
+    expect(screen.getByText('About')).toBeInTheDocument()
+  })
+
+  it('active nav item has correct data attribute', () => {
+    render(
+      <Header>
+        <Header.Nav>
+          <Header.NavItem href="#" active>Dashboard</Header.NavItem>
+        </Header.Nav>
+      </Header>
+    )
+    expect(screen.getByText('Dashboard').closest('a')).toHaveClass('bg-accent')
+  })
+
+  it('renders actions', () => {
+    render(
+      <Header>
+        <Header.Actions>
+          <Button>Sign in</Button>
+        </Header.Actions>
+      </Header>
+    )
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeInTheDocument()
+  })
+
+  it('renders as <header> element', () => {
+    render(<Header data-testid="hdr"><Header.Brand>X</Header.Brand></Header>)
+    expect(screen.getByTestId('hdr').tagName).toBe('HEADER')
+  })
+})

--- a/src/components/organisms/__tests__/Sidebar.test.tsx
+++ b/src/components/organisms/__tests__/Sidebar.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { LayoutDashboard, Settings } from 'lucide-react'
+import { Sidebar, useSidebar } from '../Sidebar'
+
+function SampleSidebar({ defaultCollapsed = false }: { defaultCollapsed?: boolean }) {
+  return (
+    <Sidebar defaultCollapsed={defaultCollapsed}>
+      <Sidebar.Header>
+        <span>My App</span>
+      </Sidebar.Header>
+      <Sidebar.Nav>
+        <Sidebar.NavItem icon={LayoutDashboard} label="Dashboard" href="#" active />
+        <Sidebar.NavItem icon={Settings} label="Settings" href="#" />
+      </Sidebar.Nav>
+      <Sidebar.Footer>Footer</Sidebar.Footer>
+    </Sidebar>
+  )
+}
+
+describe('Sidebar', () => {
+  it('renders nav items with labels', () => {
+    render(<SampleSidebar />)
+    expect(screen.getByText('Dashboard')).toBeInTheDocument()
+    expect(screen.getByText('Settings')).toBeInTheDocument()
+  })
+
+  it('active item has primary styling', () => {
+    render(<SampleSidebar />)
+    expect(screen.getByText('Dashboard').closest('a')).toHaveClass('bg-primary/10')
+  })
+
+  it('hides labels when collapsed', () => {
+    render(<SampleSidebar defaultCollapsed />)
+    expect(screen.queryByText('Dashboard')).not.toBeInTheDocument()
+    expect(screen.queryByText('Settings')).not.toBeInTheDocument()
+  })
+
+  it('renders header and footer', () => {
+    render(<SampleSidebar />)
+    expect(screen.getByText('My App')).toBeInTheDocument()
+    expect(screen.getByText('Footer')).toBeInTheDocument()
+  })
+
+  it('useSidebar provides toggle function', () => {
+    function Toggler() {
+      const { collapsed, toggle } = useSidebar()
+      return <button onClick={toggle}>{collapsed ? 'collapsed' : 'expanded'}</button>
+    }
+    render(
+      <Sidebar>
+        <Toggler />
+      </Sidebar>
+    )
+    expect(screen.getByRole('button')).toHaveTextContent('expanded')
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,15 +6,25 @@ export type { InputProps } from './components/atoms/Input';
 export { Label } from './components/atoms/Label';
 export { Icon } from './components/atoms/Icon';
 export type { IconProps } from './components/atoms/Icon';
-export { Badge } from './components/atoms/Badge';
+export { Badge, badgeVariants } from './components/atoms/Badge';
 export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './components/atoms/Tooltip';
 export { ScrollArea } from './components/atoms/ScrollArea';
 export { Card } from './components/atoms/Card';
 export { Checkbox } from './components/atoms/Checkbox';
 export { RadioGroup, RadioGroupItem } from './components/atoms/RadioGroup';
+export { Select } from './components/atoms/Select';
+export { Switch } from './components/atoms/Switch';
+export { Textarea } from './components/atoms/Textarea';
+export { Separator } from './components/atoms/Separator';
+export { Avatar } from './components/atoms/Avatar';
+export { Dialog } from './components/atoms/Dialog';
+export { Tag, tagVariants } from './components/atoms/Tag';
+export type { TagProps } from './components/atoms/Tag';
+export { Toaster, toast } from './components/atoms/Toaster';
 
 // Molecules
 export { Tabs, TabsList, TabsTrigger, TabsContent } from './components/molecules/Tabs';
+export { Form, useFormField } from './components/molecules/Form';
 export { CodeBlock } from './components/molecules/CodeBlock';
 export { StatCard } from './components/molecules/StatCard';
 export { StrategyNode } from './components/molecules/StrategyNode';
@@ -48,14 +58,14 @@ export {
 } from './components/molecules/Table';
 
 // Organisms
-export { Sidebar } from './components/organisms/Sidebar';
-export type { SidebarProps, SidebarMenuItem } from './components/organisms/Sidebar';
+export { Sidebar, useSidebar } from './components/organisms/Sidebar';
 export { Header } from './components/organisms/Header';
-export type { HeaderProps } from './components/organisms/Header';
+export type { HeaderNavItemProps } from './components/organisms/Header';
 export { PropertyPanel } from './components/organisms/PropertyPanel';
 export { NodePalette } from './components/organisms/NodePalette';
 export type { NodePaletteProps, NodeType } from './components/organisms/NodePalette';
 export { DataTable } from './components/organisms/DataTable';
+export type { DataTableProps } from './components/organisms/DataTable';
 export { StockChart } from './components/organisms/StockChart';
 export { PieChart } from './components/organisms/PieChart';
 

--- a/src/stories/atoms/Avatar.stories.tsx
+++ b/src/stories/atoms/Avatar.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Avatar } from '@/components/atoms/Avatar'
+
+const meta: Meta = {
+  title: 'Atoms/Avatar',
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+}
+export default meta
+type Story = StoryObj
+
+export const Default: Story = {
+  render: () => (
+    <Avatar>
+      <Avatar.Image src="https://github.com/shadcn.png" alt="@shadcn" />
+      <Avatar.Fallback>SC</Avatar.Fallback>
+    </Avatar>
+  ),
+}
+
+export const Fallback: Story = {
+  render: () => (
+    <Avatar>
+      <Avatar.Image src="/broken-image.png" alt="broken" />
+      <Avatar.Fallback>JS</Avatar.Fallback>
+    </Avatar>
+  ),
+}
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      {(['sm', 'md', 'lg', 'xl'] as const).map((size) => (
+        <Avatar key={size} size={size}>
+          <Avatar.Fallback>{size.toUpperCase()}</Avatar.Fallback>
+        </Avatar>
+      ))}
+    </div>
+  ),
+}

--- a/src/stories/atoms/Badge.stories.tsx
+++ b/src/stories/atoms/Badge.stories.tsx
@@ -1,48 +1,35 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { Badge } from '@/components/atoms/Badge';
+import type { Meta, StoryObj } from '@storybook/react'
+import { Badge } from '@/components/atoms/Badge'
 
-const meta = {
-    title: 'Atoms/Badge',
-    component: Badge,
-    parameters: {
-        layout: 'centered',
+const meta: Meta<typeof Badge> = {
+  title: 'Atoms/Badge',
+  component: Badge,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'secondary', 'outline', 'destructive', 'success', 'warning'],
     },
-    decorators: [
-        (Story) => (
-            <div className="bg-slate-950 p-8 flex gap-4">
-                <Story />
-            </div>
-        ),
-    ],
-} satisfies Meta<typeof Badge>;
+  },
+}
+export default meta
+type Story = StoryObj<typeof Badge>
 
-export default meta;
-type Story = StoryObj<typeof meta>;
+export const All: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <Badge variant="default">New</Badge>
+      <Badge variant="secondary">Beta</Badge>
+      <Badge variant="outline">Draft</Badge>
+      <Badge variant="success">Live</Badge>
+      <Badge variant="destructive">Error</Badge>
+      <Badge variant="warning">Review</Badge>
+    </div>
+  ),
+}
 
-export const Default: Story = {
-    args: {
-        children: 'Badge',
-        variant: 'default',
-    },
-};
-
-export const Success: Story = {
-    args: {
-        children: 'Success',
-        variant: 'success',
-    },
-};
-
-export const Destructive: Story = {
-    args: {
-        children: 'Destructive',
-        variant: 'destructive',
-    },
-};
-
-export const Outline: Story = {
-    args: {
-        children: 'Outline',
-        variant: 'outline',
-    },
-};
+export const Default: Story = { args: { children: 'New', variant: 'default' } }
+export const Success: Story = { args: { children: 'Live', variant: 'success' } }
+export const Destructive: Story = { args: { children: 'Error', variant: 'destructive' } }
+export const Outline: Story = { args: { children: 'Draft', variant: 'outline' } }

--- a/src/stories/atoms/Button.stories.tsx
+++ b/src/stories/atoms/Button.stories.tsx
@@ -1,77 +1,70 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { Button } from '@/components/atoms/Button';
+import type { Meta, StoryObj } from '@storybook/react'
+import { Search, Plus, ArrowRight } from 'lucide-react'
+import { Button } from '@/components/atoms/Button'
 
 const meta: Meta<typeof Button> = {
   title: 'Atoms/Button',
   component: Button,
   tags: ['autodocs'],
+  parameters: { layout: 'centered' },
   argTypes: {
     variant: {
-      control: { type: 'select' },
-      options: ['primary', 'secondary', 'danger', 'ghost', 'outline'],
+      control: 'select',
+      options: ['default', 'secondary', 'outline', 'ghost', 'destructive', 'link'],
     },
     size: {
-      control: { type: 'select' },
-      options: ['sm', 'md', 'lg', 'icon'],
+      control: 'select',
+      options: ['sm', 'md', 'lg', 'icon', 'icon-sm', 'icon-lg'],
     },
   },
-};
+}
+export default meta
+type Story = StoryObj<typeof Button>
 
-export default meta;
-type Story = StoryObj<typeof Button>;
-
-export const Primary: Story = {
-  args: {
-    variant: 'primary',
-    children: 'Primary Button',
-  },
-};
+export const Default: Story = {
+  args: { variant: 'default', children: 'Get started' },
+}
 
 export const Secondary: Story = {
-  args: {
-    variant: 'secondary',
-    children: 'Secondary Button',
-  },
-};
-
-export const Danger: Story = {
-  args: {
-    variant: 'danger',
-    children: 'Danger Button',
-  },
-};
-
-export const Ghost: Story = {
-  args: {
-    variant: 'ghost',
-    children: 'Ghost Button',
-  },
-};
+  args: { variant: 'secondary', children: 'Learn more' },
+}
 
 export const Outline: Story = {
-  args: {
-    variant: 'outline',
-    children: 'Outline Button',
-  },
-};
+  args: { variant: 'outline', children: 'Add to Cart' },
+}
 
-export const Large: Story = {
-  args: {
-    size: 'lg',
-    children: 'Large Button',
-  },
-};
+export const Ghost: Story = {
+  args: { variant: 'ghost', children: 'Cancel' },
+}
 
-export const Small: Story = {
-  args: {
-    size: 'sm',
-    children: 'Small Button',
-  },
-};
+export const Destructive: Story = {
+  args: { variant: 'destructive', children: 'Delete account' },
+}
 
-export const Icon: Story = {
-  args: {
-    size: 'icon',
-    children: '🔍',
-  },
-};
+export const Link: Story = {
+  args: { variant: 'link', children: 'View all →' },
+}
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-3">
+      <Button size="sm">Small</Button>
+      <Button size="md">Medium</Button>
+      <Button size="lg">Large</Button>
+    </div>
+  ),
+}
+
+export const WithIcon: Story = {
+  render: () => (
+    <div className="flex items-center gap-3">
+      <Button><Plus className="h-4 w-4" />New item</Button>
+      <Button variant="secondary"><Search className="h-4 w-4" />Search</Button>
+      <Button size="icon"><ArrowRight className="h-4 w-4" /></Button>
+    </div>
+  ),
+}
+
+export const Disabled: Story = {
+  args: { disabled: true, children: 'Unavailable' },
+}

--- a/src/stories/atoms/Card.stories.tsx
+++ b/src/stories/atoms/Card.stories.tsx
@@ -1,32 +1,62 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { Card } from '@/components/atoms/Card';
+import type { Meta, StoryObj } from '@storybook/react'
+import { Button } from '@/components/atoms/Button'
+import { Badge } from '@/components/atoms/Badge'
+import { Card } from '@/components/atoms/Card'
 
-const meta = {
-    title: 'Atoms/Card',
-    component: Card,
-    parameters: {
-        layout: 'centered',
-    },
-    decorators: [
-        (Story) => (
-            <div className="bg-slate-950 p-8 text-white">
-                <Story />
-            </div>
-        ),
-    ],
-} satisfies Meta<typeof Card>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
+const meta: Meta<typeof Card> = {
+  title: 'Atoms/Card',
+  component: Card,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+}
+export default meta
+type Story = StoryObj<typeof Card>
 
 export const Default: Story = {
-    args: {
-        className: 'p-6 w-[350px]',
-        children: (
-            <div className="space-y-2">
-                <h3 className="font-semibold leading-none tracking-tight">Notification</h3>
-                <p className="text-sm text-slate-400">You have a new message.</p>
-            </div>
-        ),
-    },
-};
+  render: () => (
+    <Card className="w-[360px]">
+      <Card.Header>
+        <Card.Title>Notification</Card.Title>
+        <Card.Description>You have 3 unread messages.</Card.Description>
+      </Card.Header>
+      <Card.Content>
+        <p className="text-sm text-muted-foreground">
+          Check your inbox to see the latest updates from your team.
+        </p>
+      </Card.Content>
+      <Card.Footer className="gap-2">
+        <Button size="sm">View all</Button>
+        <Button size="sm" variant="ghost">Dismiss</Button>
+      </Card.Footer>
+    </Card>
+  ),
+}
+
+export const Product: Story = {
+  render: () => (
+    <Card className="w-[300px] overflow-hidden">
+      <div className="aspect-video bg-muted" />
+      <Card.Header>
+        <div className="flex items-start justify-between">
+          <Card.Title className="text-base">MacBook Pro</Card.Title>
+          <Badge>New</Badge>
+        </div>
+        <Card.Description>Supercharged by M4 Pro</Card.Description>
+      </Card.Header>
+      <Card.Footer className="justify-between">
+        <span className="font-semibold">From $1,999</span>
+        <Button size="sm">Buy</Button>
+      </Card.Footer>
+    </Card>
+  ),
+}
+
+export const Simple: Story = {
+  render: () => (
+    <Card className="w-[360px]">
+      <Card.Content className="pt-6">
+        <p className="text-sm">A minimal card with just content.</p>
+      </Card.Content>
+    </Card>
+  ),
+}

--- a/src/stories/atoms/Checkbox.stories.tsx
+++ b/src/stories/atoms/Checkbox.stories.tsx
@@ -1,43 +1,45 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { Checkbox } from '@/components/atoms/Checkbox';
-import { Label } from '@/components/atoms/Label';
+import type { Meta, StoryObj } from '@storybook/react'
+import { Checkbox } from '@/components/atoms/Checkbox'
+import { Label } from '@/components/atoms/Label'
 
-const meta = {
-    title: 'Atoms/Checkbox',
-    component: Checkbox,
-    tags: ['autodocs'],
-    argTypes: {
-        checked: { control: 'boolean' },
-        disabled: { control: 'boolean' },
-    },
-} satisfies Meta<typeof Checkbox>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
+const meta: Meta<typeof Checkbox> = {
+  title: 'Atoms/Checkbox',
+  component: Checkbox,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+}
+export default meta
+type Story = StoryObj<typeof Checkbox>
 
 export const Default: Story = {
-    render: () => (
-        <div className="flex items-center space-x-2">
-            <Checkbox id="terms" />
-            <Label htmlFor="terms">Accept terms and conditions</Label>
-        </div>
-    ),
-};
-
-export const Disabled: Story = {
-    render: () => (
-        <div className="flex items-center space-x-2">
-            <Checkbox id="terms2" disabled />
-            <Label htmlFor="terms2">Accept terms and conditions</Label>
-        </div>
-    ),
-};
+  render: () => (
+    <div className="flex items-center gap-2">
+      <Checkbox id="terms" />
+      <Label htmlFor="terms">Accept terms and conditions</Label>
+    </div>
+  ),
+}
 
 export const Checked: Story = {
-    render: () => (
-        <div className="flex items-center space-x-2">
-            <Checkbox id="terms3" defaultChecked />
-            <Label htmlFor="terms3">Accept terms and conditions</Label>
-        </div>
-    ),
-};
+  render: () => (
+    <div className="flex items-center gap-2">
+      <Checkbox id="checked" defaultChecked />
+      <Label htmlFor="checked">Notifications enabled</Label>
+    </div>
+  ),
+}
+
+export const Disabled: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2">
+        <Checkbox id="d1" disabled />
+        <Label htmlFor="d1" className="opacity-50">Unavailable option</Label>
+      </div>
+      <div className="flex items-center gap-2">
+        <Checkbox id="d2" disabled defaultChecked />
+        <Label htmlFor="d2" className="opacity-50">Pre-selected, locked</Label>
+      </div>
+    </div>
+  ),
+}

--- a/src/stories/atoms/Dialog.stories.tsx
+++ b/src/stories/atoms/Dialog.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Dialog } from '@/components/atoms/Dialog'
+import { Button } from '@/components/atoms/Button'
+import { Input } from '@/components/atoms/Input'
+import { Label } from '@/components/atoms/Label'
+
+const meta: Meta = {
+  title: 'Atoms/Dialog',
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+}
+export default meta
+type Story = StoryObj
+
+export const Default: Story = {
+  render: () => (
+    <Dialog>
+      <Dialog.Trigger asChild>
+        <Button variant="outline">Open dialog</Button>
+      </Dialog.Trigger>
+      <Dialog.Content>
+        <Dialog.Header>
+          <Dialog.Title>Edit profile</Dialog.Title>
+          <Dialog.Description>
+            Make changes to your profile here. Click save when you're done.
+          </Dialog.Description>
+        </Dialog.Header>
+        <div className="grid gap-4">
+          <div className="grid gap-1.5">
+            <Label htmlFor="name">Name</Label>
+            <Input id="name" defaultValue="Junseop Shin" />
+          </div>
+          <div className="grid gap-1.5">
+            <Label htmlFor="email">Email</Label>
+            <Input id="email" type="email" defaultValue="junseop@example.com" />
+          </div>
+        </div>
+        <Dialog.Footer>
+          <Dialog.Close asChild>
+            <Button variant="ghost">Cancel</Button>
+          </Dialog.Close>
+          <Button>Save changes</Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
+  ),
+}
+
+export const Confirmation: Story = {
+  render: () => (
+    <Dialog>
+      <Dialog.Trigger asChild>
+        <Button variant="destructive">Delete account</Button>
+      </Dialog.Trigger>
+      <Dialog.Content className="max-w-sm">
+        <Dialog.Header>
+          <Dialog.Title>Are you sure?</Dialog.Title>
+          <Dialog.Description>
+            This action cannot be undone. This will permanently delete your account.
+          </Dialog.Description>
+        </Dialog.Header>
+        <Dialog.Footer>
+          <Dialog.Close asChild>
+            <Button variant="ghost">Cancel</Button>
+          </Dialog.Close>
+          <Button variant="destructive">Yes, delete</Button>
+        </Dialog.Footer>
+      </Dialog.Content>
+    </Dialog>
+  ),
+}

--- a/src/stories/atoms/Input.stories.tsx
+++ b/src/stories/atoms/Input.stories.tsx
@@ -1,45 +1,39 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { Input } from '@/components/atoms/Input';
+import type { Meta, StoryObj } from '@storybook/react'
+import { Input } from '@/components/atoms/Input'
+import { Label } from '@/components/atoms/Label'
 
 const meta: Meta<typeof Input> = {
   title: 'Atoms/Input',
   component: Input,
   tags: ['autodocs'],
-  argTypes: {
-    error: { control: 'boolean' },
-  },
-};
-
-export default meta;
-type Story = StoryObj<typeof Input>;
+  parameters: { layout: 'centered' },
+}
+export default meta
+type Story = StoryObj<typeof Input>
 
 export const Default: Story = {
-  args: {
-    placeholder: 'Type something...',
-  },
-};
+  args: { placeholder: 'Search…' },
+}
 
 export const WithLabel: Story = {
-  args: {
-    label: 'Email Address',
-    type: 'email',
-    placeholder: 'user@example.com',
-  },
-};
+  render: () => (
+    <div className="grid gap-1.5 w-72">
+      <Label htmlFor="email">Email</Label>
+      <Input id="email" type="email" placeholder="you@example.com" />
+    </div>
+  ),
+}
 
-export const WithHelperText: Story = {
-  args: {
-    label: 'Password',
-    type: 'password',
-    helperText: 'Must be at least 8 characters.',
-  },
-};
+export const Disabled: Story = {
+  args: { placeholder: 'Disabled input', disabled: true },
+}
 
-export const WithError: Story = {
-  args: {
-    label: 'Username',
-    defaultValue: 'invalid user',
-    error: true,
-    helperText: 'This username is already taken.',
-  },
-};
+export const Invalid: Story = {
+  render: () => (
+    <div className="grid gap-1.5 w-72">
+      <Label htmlFor="bad">Username</Label>
+      <Input id="bad" defaultValue="taken_name" aria-invalid="true" />
+      <p className="text-xs text-destructive">This username is already taken.</p>
+    </div>
+  ),
+}

--- a/src/stories/atoms/RadioGroup.stories.tsx
+++ b/src/stories/atoms/RadioGroup.stories.tsx
@@ -1,31 +1,40 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { RadioGroup, RadioGroupItem } from '@/components/atoms/RadioGroup';
-// import { Label } from '@/components/Label'; // Or usage of generic label
+import type { Meta, StoryObj } from '@storybook/react'
+import { RadioGroup, RadioGroupItem } from '@/components/atoms/RadioGroup'
+import { Label } from '@/components/atoms/Label'
 
 const meta: Meta<typeof RadioGroup> = {
   title: 'Atoms/RadioGroup',
   component: RadioGroup,
   tags: ['autodocs'],
-};
-
-export default meta;
-type Story = StoryObj<typeof RadioGroup>;
+  parameters: { layout: 'centered' },
+}
+export default meta
+type Story = StoryObj<typeof RadioGroup>
 
 export const Default: Story = {
   render: () => (
-    <RadioGroup defaultValue="option-one">
-      <div className="flex items-center space-x-2">
-        <RadioGroupItem value="option-one" id="r1" />
-        <label htmlFor="r1" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
-          Option One
-        </label>
+    <RadioGroup defaultValue="option-1" className="gap-3">
+      {['Option One', 'Option Two', 'Option Three'].map((label, i) => (
+        <div key={i} className="flex items-center gap-2">
+          <RadioGroupItem value={`option-${i + 1}`} id={`r${i + 1}`} />
+          <Label htmlFor={`r${i + 1}`}>{label}</Label>
+        </div>
+      ))}
+    </RadioGroup>
+  ),
+}
+
+export const Disabled: Story = {
+  render: () => (
+    <RadioGroup defaultValue="option-1" className="gap-3">
+      <div className="flex items-center gap-2">
+        <RadioGroupItem value="option-1" id="rd1" />
+        <Label htmlFor="rd1">Available</Label>
       </div>
-      <div className="flex items-center space-x-2">
-        <RadioGroupItem value="option-two" id="r2" />
-        <label htmlFor="r2" className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
-          Option Two
-        </label>
+      <div className="flex items-center gap-2">
+        <RadioGroupItem value="option-2" id="rd2" disabled />
+        <Label htmlFor="rd2" className="opacity-50">Unavailable</Label>
       </div>
     </RadioGroup>
   ),
-};
+}

--- a/src/stories/atoms/ScrollArea.stories.tsx
+++ b/src/stories/atoms/ScrollArea.stories.tsx
@@ -1,36 +1,48 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { ScrollArea } from '@/components/atoms/ScrollArea';
+import type { Meta, StoryObj } from '@storybook/react'
+import { ScrollArea } from '@/components/atoms/ScrollArea'
+import { Separator } from '@/components/atoms/Separator'
 
-const meta = {
-    title: 'Atoms/ScrollArea',
-    component: ScrollArea,
-    parameters: {
-        layout: 'centered',
-    },
-    decorators: [
-        (Story) => (
-            <div className="bg-slate-950 p-8 text-white">
-                <Story />
-            </div>
-        ),
-    ],
-} satisfies Meta<typeof ScrollArea>;
+const meta: Meta<typeof ScrollArea> = {
+  title: 'Atoms/ScrollArea',
+  component: ScrollArea,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+}
+export default meta
+type Story = StoryObj<typeof ScrollArea>
 
-export default meta;
-type Story = StoryObj<typeof meta>;
+const tags = Array.from({ length: 40 }, (_, i) => `Item ${i + 1}`)
 
 export const Default: Story = {
-    args: {
-        className: 'h-[200px] w-[350px] rounded-md border border-slate-800 p-4',
-        children: (
-            <div className="space-y-4">
-                <h4 className="mb-4 text-sm font-medium leading-none">Tags</h4>
-                {Array.from({ length: 50 }).map((_, i, a) => (
-                    <div key={i} className="text-sm">
-                        Tag {a.length - i}
-                    </div>
-                ))}
-            </div>
-        ),
-    },
-};
+  render: () => (
+    <ScrollArea className="h-64 w-56 rounded-2xl border border-border">
+      <div className="p-4">
+        <h4 className="mb-3 text-sm font-semibold">Items</h4>
+        {tags.map((tag) => (
+          <div key={tag}>
+            <p className="py-1 text-sm text-muted-foreground">{tag}</p>
+            <Separator />
+          </div>
+        ))}
+      </div>
+    </ScrollArea>
+  ),
+}
+
+export const Horizontal: Story = {
+  render: () => (
+    <ScrollArea className="w-72 rounded-2xl border border-border">
+      <div className="flex gap-3 p-4">
+        {Array.from({ length: 15 }, (_, i) => (
+          <div
+            key={i}
+            className="shrink-0 w-20 h-20 rounded-xl bg-muted flex items-center justify-center text-xs text-muted-foreground"
+          >
+            {i + 1}
+          </div>
+        ))}
+      </div>
+      <ScrollArea.ScrollBar orientation="horizontal" />
+    </ScrollArea>
+  ),
+}

--- a/src/stories/atoms/Select.stories.tsx
+++ b/src/stories/atoms/Select.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Select } from '@/components/atoms/Select'
+import { Label } from '@/components/atoms/Label'
+
+const meta: Meta = {
+  title: 'Atoms/Select',
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+}
+export default meta
+type Story = StoryObj
+
+export const Default: Story = {
+  render: () => (
+    <Select>
+      <Select.Trigger className="w-48">
+        <Select.Value placeholder="Select a fruit" />
+      </Select.Trigger>
+      <Select.Content>
+        <Select.Item value="apple">Apple</Select.Item>
+        <Select.Item value="banana">Banana</Select.Item>
+        <Select.Item value="cherry">Cherry</Select.Item>
+      </Select.Content>
+    </Select>
+  ),
+}
+
+export const WithGroups: Story = {
+  render: () => (
+    <div className="grid gap-1.5">
+      <Label>Region</Label>
+      <Select>
+        <Select.Trigger className="w-56">
+          <Select.Value placeholder="Select a timezone" />
+        </Select.Trigger>
+        <Select.Content>
+          <Select.Group>
+            <Select.Label>North America</Select.Label>
+            <Select.Item value="est">Eastern Standard Time</Select.Item>
+            <Select.Item value="cst">Central Standard Time</Select.Item>
+            <Select.Item value="pst">Pacific Standard Time</Select.Item>
+          </Select.Group>
+          <Select.Separator />
+          <Select.Group>
+            <Select.Label>Asia Pacific</Select.Label>
+            <Select.Item value="kst">Korea Standard Time</Select.Item>
+            <Select.Item value="jst">Japan Standard Time</Select.Item>
+          </Select.Group>
+        </Select.Content>
+      </Select>
+    </div>
+  ),
+}
+
+export const Disabled: Story = {
+  render: () => (
+    <Select disabled>
+      <Select.Trigger className="w-48">
+        <Select.Value placeholder="Disabled" />
+      </Select.Trigger>
+      <Select.Content>
+        <Select.Item value="x">Item</Select.Item>
+      </Select.Content>
+    </Select>
+  ),
+}

--- a/src/stories/atoms/Switch.stories.tsx
+++ b/src/stories/atoms/Switch.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Switch } from '@/components/atoms/Switch'
+import { Label } from '@/components/atoms/Label'
+
+const meta: Meta<typeof Switch> = {
+  title: 'Atoms/Switch',
+  component: Switch,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+}
+export default meta
+type Story = StoryObj<typeof Switch>
+
+export const Default: Story = {
+  render: () => (
+    <div className="flex items-center gap-3">
+      <Switch id="notifications" />
+      <Label htmlFor="notifications">Enable notifications</Label>
+    </div>
+  ),
+}
+
+export const Checked: Story = {
+  render: () => (
+    <div className="flex items-center gap-3">
+      <Switch id="s2" defaultChecked />
+      <Label htmlFor="s2">Dark mode</Label>
+    </div>
+  ),
+}
+
+export const Disabled: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-3">
+        <Switch id="d1" disabled />
+        <Label htmlFor="d1" className="opacity-50">Off, disabled</Label>
+      </div>
+      <div className="flex items-center gap-3">
+        <Switch id="d2" disabled defaultChecked />
+        <Label htmlFor="d2" className="opacity-50">On, disabled</Label>
+      </div>
+    </div>
+  ),
+}

--- a/src/stories/atoms/Tag.stories.tsx
+++ b/src/stories/atoms/Tag.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import React from 'react'
+import { Tag } from '@/components/atoms/Tag'
+
+const meta: Meta<typeof Tag> = {
+  title: 'Atoms/Tag',
+  component: Tag,
+  tags: ['autodocs'],
+  parameters: { layout: 'centered' },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'primary', 'outline', 'destructive', 'success'],
+    },
+    size: { control: 'select', options: ['sm', 'md'] },
+  },
+}
+export default meta
+type Story = StoryObj<typeof Tag>
+
+export const All: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <Tag variant="default">React</Tag>
+      <Tag variant="primary">TypeScript</Tag>
+      <Tag variant="outline">Next.js</Tag>
+      <Tag variant="success">Live</Tag>
+      <Tag variant="destructive">Deprecated</Tag>
+    </div>
+  ),
+}
+
+export const Dismissible: Story = {
+  render: () => {
+    const [tags, setTags] = React.useState(['React', 'TypeScript', 'Tailwind', 'Vite'])
+    return (
+      <div className="flex flex-wrap gap-2">
+        {tags.map((t) => (
+          <Tag key={t} variant="primary" onDismiss={() => setTags((prev) => prev.filter((x) => x !== t))}>
+            {t}
+          </Tag>
+        ))}
+      </div>
+    )
+  },
+}
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-2">
+      <Tag size="sm">Small</Tag>
+      <Tag size="md">Medium</Tag>
+    </div>
+  ),
+}

--- a/src/stories/atoms/Toaster.stories.tsx
+++ b/src/stories/atoms/Toaster.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Toaster, toast } from '@/components/atoms/Toaster'
+import { Button } from '@/components/atoms/Button'
+
+const meta: Meta = {
+  title: 'Atoms/Toaster',
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story) => (
+      <>
+        <Story />
+        <Toaster />
+      </>
+    ),
+  ],
+}
+export default meta
+type Story = StoryObj
+
+export const Default: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-2">
+      <Button onClick={() => toast('Event has been created')}>Default</Button>
+      <Button variant="secondary" onClick={() => toast.success('Changes saved!')}>Success</Button>
+      <Button variant="destructive" onClick={() => toast.error('Something went wrong')}>Error</Button>
+      <Button variant="outline" onClick={() => toast.warning('Approaching limit')}>Warning</Button>
+      <Button variant="ghost" onClick={() => toast.info('New update available')}>Info</Button>
+    </div>
+  ),
+}
+
+export const WithDescription: Story = {
+  render: () => (
+    <Button
+      onClick={() =>
+        toast('Profile updated', {
+          description: 'Your profile information has been updated successfully.',
+        })
+      }
+    >
+      Show toast with description
+    </Button>
+  ),
+}
+
+export const WithAction: Story = {
+  render: () => (
+    <Button
+      variant="destructive"
+      onClick={() =>
+        toast('File deleted', {
+          description: 'report_q3.pdf has been removed.',
+          action: { label: 'Undo', onClick: () => toast('Restored!') },
+        })
+      }
+    >
+      Delete file
+    </Button>
+  ),
+}

--- a/src/stories/atoms/Tooltip.stories.tsx
+++ b/src/stories/atoms/Tooltip.stories.tsx
@@ -1,52 +1,60 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/atoms/Tooltip';
-import { Button } from '@/components/atoms/Button';
-import { Info } from 'lucide-react';
+import type { Meta, StoryObj } from '@storybook/react'
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/atoms/Tooltip'
+import { Button } from '@/components/atoms/Button'
+import { Info } from 'lucide-react'
 
-const meta = {
-    title: 'Atoms/Tooltip',
-    component: Tooltip,
-    parameters: {
-        layout: 'centered',
-    },
-    decorators: [
-        (Story) => (
-            <div className="p-12 text-center">
-                <TooltipProvider>
-                    <Story />
-                </TooltipProvider>
-            </div>
-        ),
-    ],
-} satisfies Meta<typeof Tooltip>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
+const meta: Meta<typeof Tooltip> = {
+  title: 'Atoms/Tooltip',
+  component: Tooltip,
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story) => (
+      <TooltipProvider>
+        <div className="p-16">
+          <Story />
+        </div>
+      </TooltipProvider>
+    ),
+  ],
+}
+export default meta
+type Story = StoryObj<typeof Tooltip>
 
 export const Default: Story = {
-    render: () => (
-        <Tooltip>
-            <TooltipTrigger asChild>
-                <Button variant="outline">Hover me</Button>
-            </TooltipTrigger>
-            <TooltipContent>
-                <p>Add to library</p>
-            </TooltipContent>
-        </Tooltip>
-    ),
-};
+  render: () => (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button variant="outline">Hover me</Button>
+      </TooltipTrigger>
+      <TooltipContent>Add to library</TooltipContent>
+    </Tooltip>
+  ),
+}
 
 export const WithIcon: Story = {
-    render: () => (
-        <Tooltip>
-            <TooltipTrigger asChild>
-                <button className="text-slate-400 hover:text-white transition-colors">
-                    <Info size={16} />
-                </button>
-            </TooltipTrigger>
-            <TooltipContent side="right">
-                <p>Additional information</p>
-            </TooltipContent>
+  render: () => (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button className="text-muted-foreground hover:text-foreground transition-colors">
+          <Info size={16} />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="right">Additional information</TooltipContent>
+    </Tooltip>
+  ),
+}
+
+export const Placements: Story = {
+  render: () => (
+    <div className="flex gap-4">
+      {(['top', 'right', 'bottom', 'left'] as const).map((side) => (
+        <Tooltip key={side}>
+          <TooltipTrigger asChild>
+            <Button variant="outline" size="sm">{side}</Button>
+          </TooltipTrigger>
+          <TooltipContent side={side}>Tooltip on {side}</TooltipContent>
         </Tooltip>
-    ),
-};
+      ))}
+    </div>
+  ),
+}

--- a/src/stories/molecules/Form.stories.tsx
+++ b/src/stories/molecules/Form.stories.tsx
@@ -1,0 +1,136 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useForm } from 'react-hook-form'
+import { Form } from '@/components/molecules/Form'
+import { Input } from '@/components/atoms/Input'
+import { Button } from '@/components/atoms/Button'
+import { Select } from '@/components/atoms/Select'
+import { Checkbox } from '@/components/atoms/Checkbox'
+
+const meta: Meta = {
+  title: 'Molecules/Form',
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+}
+export default meta
+type Story = StoryObj
+
+export const LoginForm: Story = {
+  render: () => {
+    const form = useForm({
+      defaultValues: { email: '', password: '' },
+    })
+
+    return (
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit((data) => alert(JSON.stringify(data)))}
+          className="w-[360px] space-y-4"
+        >
+          <Form.Field
+            control={form.control}
+            name="email"
+            rules={{ required: 'Email is required', pattern: { value: /\S+@\S+\.\S+/, message: 'Invalid email' } }}
+            render={({ field }) => (
+              <Form.Item>
+                <Form.Label>Email</Form.Label>
+                <Form.Control>
+                  <Input placeholder="you@example.com" type="email" {...field} />
+                </Form.Control>
+                <Form.Message />
+              </Form.Item>
+            )}
+          />
+          <Form.Field
+            control={form.control}
+            name="password"
+            rules={{ required: 'Password is required', minLength: { value: 8, message: 'Min 8 characters' } }}
+            render={({ field }) => (
+              <Form.Item>
+                <Form.Label>Password</Form.Label>
+                <Form.Control>
+                  <Input placeholder="••••••••" type="password" {...field} />
+                </Form.Control>
+                <Form.Description>Must be at least 8 characters.</Form.Description>
+                <Form.Message />
+              </Form.Item>
+            )}
+          />
+          <Button type="submit" className="w-full">Sign in</Button>
+        </form>
+      </Form>
+    )
+  },
+}
+
+export const ProfileForm: Story = {
+  render: () => {
+    const form = useForm({
+      defaultValues: { name: '', role: '', newsletter: false },
+    })
+
+    return (
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit((data) => alert(JSON.stringify(data)))}
+          className="w-[400px] space-y-4"
+        >
+          <Form.Field
+            control={form.control}
+            name="name"
+            rules={{ required: 'Name is required' }}
+            render={({ field }) => (
+              <Form.Item>
+                <Form.Label>Full name</Form.Label>
+                <Form.Control>
+                  <Input placeholder="Junseop Shin" {...field} />
+                </Form.Control>
+                <Form.Message />
+              </Form.Item>
+            )}
+          />
+          <Form.Field
+            control={form.control}
+            name="role"
+            render={({ field }) => (
+              <Form.Item>
+                <Form.Label>Role</Form.Label>
+                <Form.Control>
+                  <Select onValueChange={field.onChange} defaultValue={field.value}>
+                    <Select.Trigger>
+                      <Select.Value placeholder="Select your role" />
+                    </Select.Trigger>
+                    <Select.Content>
+                      <Select.Item value="frontend">Frontend Engineer</Select.Item>
+                      <Select.Item value="backend">Backend Engineer</Select.Item>
+                      <Select.Item value="fullstack">Full Stack Engineer</Select.Item>
+                    </Select.Content>
+                  </Select>
+                </Form.Control>
+                <Form.Message />
+              </Form.Item>
+            )}
+          />
+          <Form.Field
+            control={form.control}
+            name="newsletter"
+            render={({ field }) => (
+              <Form.Item className="flex-row items-center gap-3">
+                <Form.Control>
+                  <Checkbox
+                    checked={field.value}
+                    onCheckedChange={field.onChange}
+                  />
+                </Form.Control>
+                <div>
+                  <Form.Label className="cursor-pointer">Subscribe to newsletter</Form.Label>
+                  <Form.Description>Get updates on new features.</Form.Description>
+                </div>
+              </Form.Item>
+            )}
+          />
+          <Button type="submit" className="w-full">Save profile</Button>
+        </form>
+      </Form>
+    )
+  },
+}

--- a/src/stories/molecules/Tabs.stories.tsx
+++ b/src/stories/molecules/Tabs.stories.tsx
@@ -1,44 +1,50 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/molecules/Tabs';
+import type { Meta, StoryObj } from '@storybook/react'
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/molecules/Tabs'
 
-const meta = {
-    title: 'Molecules/Tabs',
-    component: Tabs,
-    parameters: {
-        layout: 'centered',
-    },
-    decorators: [
-        (Story) => (
-            <div className="bg-slate-950 p-8 w-[400px] text-white">
-                <Story />
-            </div>
-        ),
-    ],
-} satisfies Meta<typeof Tabs>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
+const meta: Meta<typeof Tabs> = {
+  title: 'Molecules/Tabs',
+  component: Tabs,
+  parameters: { layout: 'centered' },
+  tags: ['autodocs'],
+}
+export default meta
+type Story = StoryObj<typeof Tabs>
 
 export const Default: Story = {
-    args: {
-        defaultValue: 'account',
-        children: (
-            <>
-                <TabsList className="grid w-full grid-cols-2">
-                    <TabsTrigger value="account">Account</TabsTrigger>
-                    <TabsTrigger value="password">Password</TabsTrigger>
-                </TabsList>
-                <TabsContent value="account">
-                    <div className="p-4 rounded border border-slate-800 bg-slate-900 mt-2">
-                        Make changes to your account here.
-                    </div>
-                </TabsContent>
-                <TabsContent value="password">
-                    <div className="p-4 rounded border border-slate-800 bg-slate-900 mt-2">
-                        Change your password here.
-                    </div>
-                </TabsContent>
-            </>
-        ),
-    },
-};
+  render: () => (
+    <Tabs defaultValue="account" className="w-[400px]">
+      <Tabs.List>
+        <Tabs.Trigger value="account">Account</Tabs.Trigger>
+        <Tabs.Trigger value="password">Password</Tabs.Trigger>
+        <Tabs.Trigger value="settings">Settings</Tabs.Trigger>
+      </Tabs.List>
+      <Tabs.Content value="account">
+        <p className="text-sm text-muted-foreground">Make changes to your account here.</p>
+      </Tabs.Content>
+      <Tabs.Content value="password">
+        <p className="text-sm text-muted-foreground">Change your password here.</p>
+      </Tabs.Content>
+      <Tabs.Content value="settings">
+        <p className="text-sm text-muted-foreground">Manage your settings here.</p>
+      </Tabs.Content>
+    </Tabs>
+  ),
+}
+
+export const WithDisabled: Story = {
+  render: () => (
+    <Tabs defaultValue="tab1" className="w-[400px]">
+      <Tabs.List>
+        <Tabs.Trigger value="tab1">Active</Tabs.Trigger>
+        <Tabs.Trigger value="tab2" disabled>Disabled</Tabs.Trigger>
+        <Tabs.Trigger value="tab3">Other</Tabs.Trigger>
+      </Tabs.List>
+      <Tabs.Content value="tab1">
+        <p className="text-sm text-muted-foreground">Active tab content.</p>
+      </Tabs.Content>
+      <Tabs.Content value="tab3">
+        <p className="text-sm text-muted-foreground">Other tab content.</p>
+      </Tabs.Content>
+    </Tabs>
+  ),
+}

--- a/src/stories/organisms/Header.stories.tsx
+++ b/src/stories/organisms/Header.stories.tsx
@@ -1,27 +1,58 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { Header } from '@/components/organisms/Header';
+import type { Meta, StoryObj } from '@storybook/react'
+import { Bell, Search, Moon } from 'lucide-react'
+import { Header } from '@/components/organisms/Header'
+import { Button } from '@/components/atoms/Button'
+import { Avatar } from '@/components/atoms/Avatar'
+import { Input } from '@/components/atoms/Input'
 
-const meta = {
-    title: 'Organisms/Header',
-    component: Header,
-    parameters: {
-        layout: 'fullscreen',
-    },
-    decorators: [
-        (Story) => (
-            <div className="min-h-screen bg-slate-950 text-white">
-                <Story />
-            </div>
-        ),
-    ],
-} satisfies Meta<typeof Header>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
+const meta: Meta<typeof Header> = {
+  title: 'Organisms/Header',
+  component: Header,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+}
+export default meta
+type Story = StoryObj<typeof Header>
 
 export const Default: Story = {
-    args: {
-        user: { name: '개발자', role: '관리자' },
-        searchPlaceholder: '시장 또는 전략 검색...',
-    }
-};
+  render: () => (
+    <Header>
+      <Header.Brand>
+        <span className="text-lg font-semibold tracking-tight">Acme</span>
+      </Header.Brand>
+      <Header.Nav className="ml-8">
+        <Header.NavItem href="#" active>Overview</Header.NavItem>
+        <Header.NavItem href="#">Analytics</Header.NavItem>
+        <Header.NavItem href="#">Projects</Header.NavItem>
+      </Header.Nav>
+      <Header.Actions>
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+          <Input placeholder="Search…" className="w-52 h-8 pl-8 text-xs" />
+        </div>
+        <Button variant="ghost" size="icon-sm">
+          <Bell className="h-4 w-4" />
+        </Button>
+        <Button variant="ghost" size="icon-sm">
+          <Moon className="h-4 w-4" />
+        </Button>
+        <Avatar size="sm">
+          <Avatar.Fallback>JS</Avatar.Fallback>
+        </Avatar>
+      </Header.Actions>
+    </Header>
+  ),
+}
+
+export const Minimal: Story = {
+  render: () => (
+    <Header>
+      <Header.Brand>
+        <span className="font-bold">My App</span>
+      </Header.Brand>
+      <Header.Actions>
+        <Button size="sm">Sign in</Button>
+      </Header.Actions>
+    </Header>
+  ),
+}

--- a/src/stories/organisms/Sidebar.stories.tsx
+++ b/src/stories/organisms/Sidebar.stories.tsx
@@ -1,37 +1,65 @@
-import type { Meta, StoryObj } from '@storybook/react';
-import { Sidebar } from '@/components/organisms/Sidebar';
+import type { Meta, StoryObj } from '@storybook/react'
+import {
+  LayoutDashboard, TrendingUp, Layers, Settings, Activity, LogOut
+} from 'lucide-react'
+import { Sidebar } from '@/components/organisms/Sidebar'
+import { Button } from '@/components/atoms/Button'
+import { Avatar } from '@/components/atoms/Avatar'
 
-const meta = {
-    title: 'Organisms/Sidebar',
-    component: Sidebar,
-    parameters: {
-        layout: 'fullscreen',
-    },
-    decorators: [
-        (Story) => (
-            <div className="min-h-screen bg-slate-950">
-                <Story />
-            </div>
-        ),
-    ],
-} satisfies Meta<typeof Sidebar>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
-
-import { LayoutDashboard, TrendingUp, Layers, Settings, Activity } from 'lucide-react';
-
-const exampleMenuItems = [
-    { name: '대시보드', icon: LayoutDashboard, href: '/dashboard' },
-    { name: '전략 빌더', icon: Layers, href: '/strategies/builder' },
-    { name: '내 전략', icon: TrendingUp, href: '/strategies' },
-    { name: '시스템 상태', icon: Activity, href: '/status' },
-    { name: '설정', icon: Settings, href: '/settings' },
-];
+const meta: Meta<typeof Sidebar> = {
+  title: 'Organisms/Sidebar',
+  component: Sidebar,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+}
+export default meta
+type Story = StoryObj<typeof Sidebar>
 
 export const Default: Story = {
-    args: {
-        menuItems: exampleMenuItems,
-        title: "KIS 트레이더",
-    },
-};
+  render: () => (
+    <div className="relative h-[600px]">
+      <Sidebar>
+        <Sidebar.Header>
+          <TrendingUp className="h-5 w-5 text-primary" />
+          <span className="font-semibold">KIS Trader</span>
+        </Sidebar.Header>
+        <Sidebar.Nav>
+          <Sidebar.NavItem icon={LayoutDashboard} label="Dashboard" href="#" active />
+          <Sidebar.NavItem icon={Layers} label="Strategy Builder" href="#" />
+          <Sidebar.NavItem icon={TrendingUp} label="My Strategies" href="#" />
+          <Sidebar.NavItem icon={Activity} label="System Status" href="#" />
+          <Sidebar.NavItem icon={Settings} label="Settings" href="#" />
+        </Sidebar.Nav>
+        <Sidebar.Footer>
+          <div className="flex items-center gap-3">
+            <Avatar size="sm"><Avatar.Fallback>JS</Avatar.Fallback></Avatar>
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-medium truncate">Junseop Shin</p>
+              <p className="text-xs text-muted-foreground truncate">Admin</p>
+            </div>
+            <Button variant="ghost" size="icon-sm">
+              <LogOut className="h-4 w-4" />
+            </Button>
+          </div>
+        </Sidebar.Footer>
+      </Sidebar>
+    </div>
+  ),
+}
+
+export const Collapsed: Story = {
+  render: () => (
+    <div className="relative h-[600px]">
+      <Sidebar defaultCollapsed>
+        <Sidebar.Header>
+          <TrendingUp className="h-5 w-5 text-primary" />
+        </Sidebar.Header>
+        <Sidebar.Nav>
+          <Sidebar.NavItem icon={LayoutDashboard} label="Dashboard" href="#" active />
+          <Sidebar.NavItem icon={Layers} label="Strategy Builder" href="#" />
+          <Sidebar.NavItem icon={Settings} label="Settings" href="#" />
+        </Sidebar.Nav>
+      </Sidebar>
+    </div>
+  ),
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,171 +1,175 @@
 @import "tailwindcss";
 
-@theme {
-  --font-button: "Nunito Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  --inset-shadow-button: rgba(0, 0, 0, 0.15) 0px 0px 0px 1px inset;
-
-  --font-header: "Nunito Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  --font-page: "Nunito Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
-
+@theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
   --color-primary: var(--primary);
   --color-primary-foreground: var(--primary-foreground);
-
   --color-secondary: var(--secondary);
   --color-secondary-foreground: var(--secondary-foreground);
-
-  --color-destructive: var(--destructive);
-  --color-destructive-foreground: var(--destructive-foreground);
-
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
-
-  --color-popover: var(--popover);
-  --color-popover-foreground: var(--popover-foreground);
-
-  --color-card: var(--card);
-  --color-card-foreground: var(--card-foreground);
-
-  /* Semantic Colors for Finance */
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
   --color-success: var(--success);
   --color-success-foreground: var(--success-foreground);
-
   --color-warning: var(--warning);
   --color-warning-foreground: var(--warning-foreground);
-
-  --color-info: var(--info);
-  --color-info-foreground: var(--info-foreground);
-
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: var(--radius);
+  --radius-lg: calc(var(--radius) + 4px);
+  --radius-xl: calc(var(--radius) + 8px);
+  --radius-2xl: calc(var(--radius) + 16px);
+  --font-sans: var(--font-family-sans);
 }
 
-/* Base Variables (Default: Light) */
+/* ─── Light (default) ─── */
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.129 0.042 264.695);
+  --background: oklch(100% 0 0);
+  --foreground: oklch(13% 0.004 285);
 
-  --primary: oklch(0.208 0.042 265.755);
-  --primary-foreground: oklch(0.984 0.003 247.858);
+  --card: oklch(100% 0 0);
+  --card-foreground: oklch(13% 0.004 285);
 
-  --secondary: oklch(0.968 0.007 247.896);
-  --secondary-foreground: oklch(0.208 0.042 265.755);
+  --popover: oklch(100% 0 0);
+  --popover-foreground: oklch(13% 0.004 285);
 
-  --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.984 0.003 247.858);
+  /* Apple Blue #0071e3 */
+  --primary: oklch(51% 0.195 256);
+  --primary-foreground: oklch(100% 0 0);
 
-  --accent: oklch(0.968 0.007 247.896);
-  --accent-foreground: oklch(0.208 0.042 265.755);
+  /* #f5f5f7 */
+  --secondary: oklch(97% 0.002 285);
+  --secondary-foreground: oklch(13% 0.004 285);
 
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.129 0.042 264.695);
+  --muted: oklch(97% 0.002 285);
+  --muted-foreground: oklch(45% 0.005 285);
 
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.129 0.042 264.695);
+  --accent: oklch(94% 0.003 285);
+  --accent-foreground: oklch(13% 0.004 285);
 
-  --border: oklch(0.929 0.013 255.508);
-  --input: oklch(0.929 0.013 255.508);
-  --ring: oklch(0.869 0.022 252.894);
+  --destructive: oklch(54% 0.22 25);
+  --destructive-foreground: oklch(100% 0 0);
 
-  --success: oklch(0.627 0.265 149);
-  --success-foreground: oklch(0.985 0 0);
+  --success: oklch(60% 0.17 142);
+  --success-foreground: oklch(100% 0 0);
 
-  --warning: oklch(0.769 0.188 70);
-  --warning-foreground: oklch(0.205 0.042 50);
+  --warning: oklch(80% 0.16 80);
+  --warning-foreground: oklch(13% 0.004 285);
 
-  --info: oklch(0.536 0.198 253);
-  --info-foreground: oklch(0.985 0 0);
+  --border: oklch(90% 0.003 285);
+  --input: oklch(90% 0.003 285);
+  --ring: oklch(51% 0.195 256);
 
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
+  --radius: 0.75rem;
+  --font-family-sans: -apple-system, BlinkMacSystemFont, "SF Pro Display", "SF Pro Text", system-ui, sans-serif;
+
   color-scheme: light;
 }
 
-/* Dark Theme */
+/* ─── Dark ─── */
 .dark {
-  --background: oklch(0.129 0.042 264.695);
-  --foreground: oklch(0.984 0.003 247.858);
+  --background: oklch(0% 0 0);
+  --foreground: oklch(96% 0.002 285);
 
-  --primary: oklch(0.984 0.003 247.858);
-  --primary-foreground: oklch(0.208 0.042 265.755);
+  --card: oklch(11% 0.003 285);
+  --card-foreground: oklch(96% 0.002 285);
 
-  --secondary: oklch(0.279 0.041 260.031);
-  --secondary-foreground: oklch(0.984 0.003 247.858);
+  --popover: oklch(11% 0.003 285);
+  --popover-foreground: oklch(96% 0.002 285);
 
-  --destructive: oklch(0.396 0.141 25.723);
-  --destructive-foreground: oklch(0.984 0.003 247.858);
+  /* Apple Blue dark #2997ff */
+  --primary: oklch(68% 0.18 256);
+  --primary-foreground: oklch(100% 0 0);
 
-  --accent: oklch(0.279 0.041 260.031);
-  --accent-foreground: oklch(0.984 0.003 247.858);
+  /* #1c1c1e */
+  --secondary: oklch(15% 0.003 285);
+  --secondary-foreground: oklch(96% 0.002 285);
 
-  --popover: oklch(0.129 0.042 264.695);
-  --popover-foreground: oklch(0.984 0.003 247.858);
+  --muted: oklch(15% 0.003 285);
+  --muted-foreground: oklch(62% 0.005 285);
 
-  --card: oklch(0.129 0.042 264.695);
-  --card-foreground: oklch(0.984 0.003 247.858);
+  --accent: oklch(18% 0.003 285);
+  --accent-foreground: oklch(96% 0.002 285);
 
-  --border: oklch(0.279 0.041 260.031);
-  --input: oklch(0.279 0.041 260.031);
-  --ring: oklch(0.446 0.043 257.281);
+  --destructive: oklch(60% 0.22 25);
+  --destructive-foreground: oklch(100% 0 0);
 
-  --success: oklch(0.627 0.265 149);
-  --warning: oklch(0.769 0.188 70);
-  --info: oklch(0.536 0.198 253);
+  --success: oklch(65% 0.17 142);
+  --success-foreground: oklch(100% 0 0);
+
+  --warning: oklch(82% 0.16 80);
+  --warning-foreground: oklch(13% 0.004 285);
+
+  --border: oklch(22% 0.004 285);
+  --input: oklch(22% 0.004 285);
+  --ring: oklch(68% 0.18 256);
 
   color-scheme: dark;
 }
 
-/* Finance Theme (Navy & Neon) - Using OKLAB as requested */
+/* ─── Finance (legacy) ─── */
 .finance {
   --background: oklab(0.12 -0.01 -0.04);
-  /* Deep Navy */
   --foreground: oklab(0.88 -0.01 -0.01);
-  /* Light Slate */
+
+  --card: oklab(0.20 -0.01 -0.03);
+  --card-foreground: oklab(0.88 -0.01 -0.01);
+
+  --popover: oklab(0.10 -0.01 -0.04);
+  --popover-foreground: oklab(0.88 -0.01 -0.01);
 
   --primary: oklab(0.55 -0.05 -0.18);
-  /* Finance Blue */
   --primary-foreground: oklab(1 0 0);
 
   --secondary: oklab(0.20 -0.01 -0.03);
-  /* Slate 800 */
   --secondary-foreground: oklab(0.95 0 0);
 
-  --destructive: oklab(0.60 0.18 0.10);
-  /* Fluorescent Red */
-  --destructive-foreground: oklab(1 0 0);
+  --muted: oklab(0.20 -0.01 -0.03);
+  --muted-foreground: oklab(0.65 0.01 -0.10);
 
   --accent: oklab(0.20 -0.01 -0.03);
   --accent-foreground: oklab(0.60 -0.02 -0.10);
 
-  --popover: oklab(0.10 -0.01 -0.04);
-  /* Darker than BG */
-  --popover-foreground: oklab(0.88 -0.01 -0.01);
+  --destructive: oklab(0.60 0.18 0.10);
+  --destructive-foreground: oklab(1 0 0);
 
-  --card: oklab(0.20 -0.01 -0.03);
-  --card-foreground: oklab(0.88 -0.01 -0.01);
+  --success: oklab(0.65 -0.15 0.05);
+  --success-foreground: oklab(1 0 0);
+
+  --warning: oklab(0.70 0.05 0.15);
+  --warning-foreground: oklab(0.13 0 0);
 
   --border: oklab(0.30 -0.01 -0.04);
   --input: oklab(0.30 -0.01 -0.04);
   --ring: oklab(0.55 -0.05 -0.18);
 
-  --success: oklab(0.65 -0.15 0.05);
-  /* Emerald */
-  --warning: oklab(0.70 0.05 0.15);
-  /* Amber */
-  --info: oklab(0.60 -0.08 -0.15);
-  /* Sky */
-
   color-scheme: dark;
+}
+
+/* ─── Base ─── */
+*,
+*::before,
+*::after {
+  border-color: var(--border);
+  outline-color: var(--ring);
 }
 
 body {
   background-color: var(--background);
   color: var(--foreground);
+  font-family: var(--font-family-sans);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   margin: 0;
-  min-width: 320px;
   min-height: 100vh;
 }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -32,5 +32,11 @@
   },
   "include": [
     "src"
+  ],
+  "exclude": [
+    "src/**/__tests__/**",
+    "src/**/*.test.tsx",
+    "src/**/*.test.ts",
+    "src/stories/**"
   ]
 }


### PR DESCRIPTION
## Summary
- Rebuild all atoms/molecules/organisms as Radix-based compound components (`Object.assign` pattern, internal Context, no prop drilling)
- Apply Apple Store design tokens (OKLCH colors, SF Pro font stack, `rounded-full` buttons, `rounded-2xl` cards)
- Add new atoms: Select, Switch, Textarea, Separator, Avatar, Dialog, Tag, Toaster (Sonner)
- Add Form molecule with react-hook-form compound pattern (`Form.Field`, `Form.Item`, `Form.Label`, `Form.Control`, `Form.Message`)
- Rebuild Header/Sidebar as pure React compound components (removed Next.js dependency)
- Add 74 Vitest tests across atoms/molecules/organisms
- Update all Storybook stories

## Breaking Changes
- `SidebarProps`, `SidebarMenuItem`, `HeaderProps` types removed (replaced by compound sub-component props)
- `Header`/`Sidebar` no longer depend on `next/link` or `usePathname`
- Version bumped `0.0.4` → `0.1.0`

## Test plan
- [ ] `npm run test` — 74 tests pass
- [ ] `npm run build` — builds successfully
- [ ] `npm run storybook` — all stories render

🤖 Generated with [Claude Code](https://claude.com/claude-code)