### PR TITLE
chore: add auto-publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,22 +1,54 @@
-name: Publish Package
+name: Publish to GitHub Packages
 
 on:
-  release:
-    types: [created]
+  push:
+    branches:
+      - main
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '20'
           registry-url: 'https://npm.pkg.github.com'
-      - run: npm ci
-      - run: npm publish
+          scope: '@junseop-shin'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check if version changed
+        id: version-check
+        run: |
+          CURRENT=$(node -p "require('./package.json').version")
+          PUBLISHED=$(npm view @junseop-shin/my-ui-lib version --registry https://npm.pkg.github.com 2>/dev/null || echo "none")
+          echo "current=$CURRENT" >> $GITHUB_OUTPUT
+          echo "published=$PUBLISHED" >> $GITHUB_OUTPUT
+          if [ "$CURRENT" != "$PUBLISHED" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build
+        if: steps.version-check.outputs.changed == 'true'
+        run: npm run build
+
+      - name: Publish
+        if: steps.version-check.outputs.changed == 'true'
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Skip (version unchanged)
+        if: steps.version-check.outputs.changed == 'false'
+        run: echo "Version ${{ steps.version-check.outputs.current }} already published. Skipping."


### PR DESCRIPTION
## Summary
- GitHub Actions workflow that auto-publishes to GitHub Packages on push to main
- Version check: only publishes if `package.json` version differs from latest published
- Uses `GITHUB_TOKEN` (built-in, no extra secrets needed)

## How it works
1. PR에서 `package.json` version 올리고 머지
2. main에 push 이벤트 발생 → workflow 트리거
3. 현재 버전 vs 마지막 published 버전 비교
4. 버전이 다르면 build + publish, 같으면 skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)