### PR TITLE
feat: add Storybook deploy workflow to home server

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,27 +1,74 @@
-name: Storybook Build & Test
+name: Storybook Build & Deploy
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
+  push:
+    branches: ["main"]
 
 jobs:
   build-and-test:
+    name: Build & Test (PR)
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Use Node.js 20.x
-      uses: actions/setup-node@v4
-      with:
-        node-version: 20.x
-        cache: 'npm'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: "npm"
 
-    - name: Install dependencies
-      run: npm ci
+      - name: Install dependencies
+        run: npm ci
 
-    - name: Run Type Check
-      run: npm run build # Includes tsc
+      - name: Type Check
+        run: npm run build
 
-    - name: Build Storybook
-      run: npm run build-storybook
+      - name: Build Storybook
+        run: npm run build-storybook
+
+  deploy:
+    name: Deploy Storybook
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Storybook
+        run: npm run build-storybook
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
+          ssh-keyscan -p ${{ secrets.DEPLOY_PORT || 22 }} ${{ secrets.DEPLOY_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Sync Storybook static files
+        run: |
+          rsync -avz --delete \
+            -e "ssh -i ~/.ssh/id_deploy -p ${{ secrets.DEPLOY_PORT || 22 }}" \
+            storybook-static/ \
+            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:${{ secrets.STORYBOOK_PATH }}/
+
+      - name: Reload Storybook server
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: ${{ secrets.DEPLOY_PORT || 22 }}
+          script: |
+            pm2 reload storybook --update-env || pm2 serve ${{ secrets.STORYBOOK_PATH }} 6006 --name "storybook" --spa
+            pm2 save


### PR DESCRIPTION
## Summary
- PR 시: build + type check만 실행 (기존 동작 유지)
- main push 시: Storybook 빌드 → rsync → pm2 serve로 홈 서버 배포

## Deploy flow
1. Runner에서 `npm run build-storybook` → `storybook-static/`
2. `rsync` → 홈 서버 `STORYBOOK_PATH`로 전송
3. `pm2 serve` port 6006으로 정적 파일 서빙

## Required Secrets
`DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_SSH_KEY`, `DEPLOY_PORT`, `STORYBOOK_PATH`

## Cloudflare Tunnel
`storybook.nuclearbomb.site` → `localhost:6006` 추가 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)