### PR TITLE
feat(deploy): add Storybook deploy to Windows home server

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,27 +1,71 @@
-name: Storybook Build & Test
+name: Storybook Build & Deploy
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
+  push:
+    branches: ["main"]
 
 jobs:
   build-and-test:
+    name: Build & Test (PR)
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Use Node.js 20.x
-      uses: actions/setup-node@v4
-      with:
-        node-version: 20.x
-        cache: 'npm'
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: "npm"
 
-    - name: Install dependencies
-      run: npm ci
+      - name: Install dependencies
+        run: npm ci
 
-    - name: Run Type Check
-      run: npm run build # Includes tsc
+      - name: Type Check
+        run: npm run build
 
-    - name: Build Storybook
-      run: npm run build-storybook
+      - name: Build Storybook
+        run: npm run build-storybook
+
+  deploy:
+    name: Deploy Storybook
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Storybook
+        run: npm run build-storybook
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" | base64 -d > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
+
+      - name: Sync Storybook static files
+        run: |
+          SSH="ssh -i ~/.ssh/id_deploy -p ${{ secrets.DEPLOY_PORT }} -o StrictHostKeyChecking=no ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}"
+          $SSH "pm2 stop storybook" || true
+          $SSH "if exist \"${{ secrets.STORYBOOK_PATH }}\" rmdir /s /q \"${{ secrets.STORYBOOK_PATH }}\"" || true
+          $SSH "mkdir \"${{ secrets.STORYBOOK_PATH }}\""
+          tar czf - -C storybook-static . | $SSH "tar xzf - -C ${{ secrets.STORYBOOK_PATH }}"
+
+      - name: Reload Storybook server
+        run: |
+          ssh -i ~/.ssh/id_deploy \
+            -p ${{ secrets.DEPLOY_PORT }} \
+            -o StrictHostKeyChecking=no \
+            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
+            "pm2 reload storybook --update-env || pm2 serve ${{ secrets.STORYBOOK_PATH }} 6006 --name storybook --spa && pm2 save && schtasks /run /tn PM2-Resurrect"


### PR DESCRIPTION
## Summary
- Add deploy job (push to main) alongside existing PR build-and-test job
- Transfer `storybook-static/` via `tar | ssh` (rsync not available on Windows)
- Decode `DEPLOY_SSH_KEY` from base64 to handle PEM format correctly
- Stop `pm2 storybook` before sync to release Windows file locks
- Serve static files with `pm2 serve` on port 6006 → `storybook.nuclearbomb6518.com`
- Trigger `PM2-Resurrect` Task Scheduler task so pm2 daemon survives SSH session end

## Secrets required (my-ui-lib repo)
| Secret | Value |
|--------|-------|
| `DEPLOY_HOST` | `windows.nuclearbomb6518.com` |
| `DEPLOY_PORT` | `2222` ✅ added |
| `DEPLOY_USER` | `ylswn` |
| `DEPLOY_SSH_KEY` | base64 encoded ✅ updated |
| `STORYBOOK_PATH` | Windows path to storybook static dir |

## Test plan
- [ ] Push to main triggers deploy job
- [ ] `storybook-static/` transferred successfully
- [ ] `https://storybook.nuclearbomb6518.com` accessible after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)